### PR TITLE
Updates rust used by the containerized runner from 1.37 to 1.40

### DIFF
--- a/webui_runner/Dockerfile
+++ b/webui_runner/Dockerfile
@@ -20,12 +20,12 @@ RUN ln -s /usr/bin/wasm-ld-8 /usr/bin/wasm-ld
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-RUN curl -sS -L -O https://static.rust-lang.org/dist/rust-1.37.0-x86_64-unknown-linux-gnu.tar.gz \
-	&& tar xzf rust-1.37.0-x86_64-unknown-linux-gnu.tar.gz \
-	&& cd rust-1.37.0-x86_64-unknown-linux-gnu \
+RUN curl -sS -L -O https://static.rust-lang.org/dist/rust-1.40.0-x86_64-unknown-linux-gnu.tar.gz \
+	&& tar xzf rust-1.40.0-x86_64-unknown-linux-gnu.tar.gz \
+	&& cd rust-1.40.0-x86_64-unknown-linux-gnu \
 	&& ./install.sh \
 	&& cd .. \
-	&& rm -rf rust-1.37.0-x86_64-unknown-linux-gnu rust-1.37.0-x86_64-unknown-linux-gnu.tar.gz
+	&& rm -rf rust-1.40.0-x86_64-unknown-linux-gnu rust-1.40.0-x86_64-unknown-linux-gnu.tar.gz
 
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
 

--- a/webui_runner/plugs/lucet_app/download.sh
+++ b/webui_runner/plugs/lucet_app/download.sh
@@ -5,7 +5,7 @@ source ../../config.inc
 >&2 echo "lucet_app download"
 mkdir -p build; cd build
 if [ ! -d lucet ]; then 
-    git clone https://github.com/fastly/lucet.git lucet
+    git clone https://github.com/bytecodealliance/lucet.git lucet
 fi
 cd lucet
 git clean -fd

--- a/webui_runner/plugs/wasmtime_app/download.sh
+++ b/webui_runner/plugs/wasmtime_app/download.sh
@@ -3,7 +3,7 @@
 >&2 echo "wasmtime_app build"
 mkdir -p build; cd build
 if [ ! -d wasmtime ]; then
-    git clone https://github.com/CraneStation/wasmtime.git wasmtime
+    git clone https://github.com/bytecodealliance/wasmtime.git wasmtime
 fi
 cd wasmtime
 git clean -fd


### PR DESCRIPTION
Wasmtime no longer builds. This was debug to be an error parsing
cargo.lock while building. According to https://github.com/rust-lang/cargo/pull/7579
it seems rust prior to 1.38 is now obsolete w.r.t. to changes
to the lock file format.

Also updates the url for the repositories pointed to for wasmtime and lucet.