### PR TITLE
History URL updated from localhost:8001 to localhost:8001/history

### DIFF
--- a/webui/sg-view/nuxt.config.js
+++ b/webui/sg-view/nuxt.config.js
@@ -16,11 +16,11 @@ module.exports = {
   head: {
     title: "sg-view",
     meta: [
-      {charset: "utf-8"},
-      {name: "viewport", content: "width=device-width, initial-scale=1"},
-      {hid: "description", name: "description", content: "SightGlass viewer"}
+      { charset: "utf-8" },
+      { name: "viewport", content: "width=device-width, initial-scale=1" },
+      { hid: "description", name: "description", content: "SightGlass viewer" }
     ],
-    link: [{rel: "icon", type: "image/x-icon", href: "/favicon.ico"}]
+    link: [{ rel: "icon", type: "image/x-icon", href: "/favicon.ico" }]
   },
 
   css: [
@@ -33,7 +33,7 @@ module.exports = {
   /*
   ** Customize the progress bar color
   */
-  loading: {color: "#3B8070"},
+  loading: { color: "#3B8070" },
   /*
   ** Build configuration
   */
@@ -42,7 +42,7 @@ module.exports = {
     /*
     ** Run ESLint on save
     */
-    extend(config, {isDev, isClient}) {
+    extend(config, { isDev, isClient }) {
       if (isDev && isClient) {
         config.module.rules.push({
           enforce: "pre",
@@ -59,6 +59,6 @@ module.exports = {
   ** this line may seem redundant, it ensures that the client receives the server-defined variable.
    */
   env: {
-    HISTORY_URL: process.env.HISTORY_URL || 'http://localhost:8001',
+    HISTORY_URL: process.env.HISTORY_URL || 'http://localhost:8001/history',
   }
 };


### PR DESCRIPTION
sg-viewer was not finding the history files. This seems to be due to
an incorrect history fetch url which is set in different ways. This
patch updates the default URL which seemed to be missing the appended /history.