### PR TITLE
Replace failure with thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,28 +381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
-dependencies = [
- "proc-macro2 0.4.27",
- "quote 0.6.11",
- "syn 0.15.30",
- "synstructure",
-]
-
-[[package]]
 name = "filetime"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,7 +1248,6 @@ dependencies = [
  "bencher",
  "clap",
  "core_affinity",
- "failure",
  "goblin",
  "hwloc",
  "libc 0.2.81",
@@ -1280,8 +1257,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "thiserror",
  "toml",
- "xfailure",
 ]
 
 [[package]]
@@ -1391,18 +1368,6 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "unicode-xid 0.2.1",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
-dependencies = [
- "proc-macro2 0.4.27",
- "quote 0.6.11",
- "syn 0.15.30",
- "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -1739,9 +1704,3 @@ dependencies = [
  "raw-cpuid",
  "serde_json",
 ]
-
-[[package]]
-name = "xfailure"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da90eac47bf1d7871b75004b9b631d107df15f37669383b23f0b5297bc7516b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license = "Apache-2.0 WITH LLVM-exception OR MIT"
 [dependencies]
 bencher = "0.1"
 clap = "2"
-failure = "0.1"
 goblin = "0.0"
 libc = "0.2"
 libloading = "0.5"
@@ -21,8 +20,8 @@ printtable = "0.1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+thiserror = "1"
 toml = "0.5"
-xfailure = "0.1"
 
 [target.'cfg(any(target_os="windows",target_os="macos",target_os="linux"))'.dependencies]
 core_affinity="0.5.9"

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -338,7 +338,7 @@ fn bench_library(config: &Config, library_path: &Path) -> Result<Vec<TestResult>
     let tests_runner: Symbol<'_, &TestsConfig> =
         unsafe { library.get(TEST_LIBRARIES_TABLE_SYMBOL) }.map_err(BenchError::from)?;
     if tests_runner.version != TEST_ABI_VERSION {
-        xbail!(BenchError::ABIError("Incompatible ABI version"));
+        return Err(BenchError::ABIError("Incompatible ABI version"));
     }
     let tests = symbols::resolve(&tests_symbols, &library);
     let mut global_ctx: TestCtx = ptr::null_mut();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,23 +1,17 @@
 use std::io;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum BenchError {
-    #[fail(display = "Internal error: {}", _0)]
+    #[error("Internal error: {0}")]
     InternalError(&'static str),
-    #[fail(display = "ABI error: {}", _0)]
+    #[error("ABI error: {0}")]
     ABIError(&'static str),
-    #[fail(display = "Parse error: {}", _0)]
+    #[error("Parse error: {0}")]
     ParseError(String),
-    #[fail(display = "{}", _0)]
-    Io(#[cause] io::Error),
-    #[fail(display = "Unsupported")]
+    #[error("{0}")]
+    Io(#[from] io::Error),
+    #[error("Unsupported")]
     Unsupported,
-}
-
-impl From<io::Error> for BenchError {
-    fn from(e: io::Error) -> BenchError {
-        BenchError::Io(e)
-    }
 }
 
 impl From<&'static str> for BenchError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,8 @@
 #[macro_use]
-extern crate failure;
-
-#[macro_use]
 extern crate serde_derive;
 
 #[macro_use]
-extern crate xfailure;
+extern crate thiserror;
 
 mod bench;
 mod config;

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -62,7 +62,7 @@ fn exported_names_from_library<P: AsRef<Path>>(path: P) -> Result<Vec<String>, B
                 }
             }
         }
-        _ => xbail!(BenchError::Unsupported),
+        _ => return Err(BenchError::Unsupported),
     }
     Ok(names)
 }


### PR DESCRIPTION
`failure` has been deprecated in favor of `thiserror`.