### PR TITLE
Allow benchmarks to run multiple times with CLI flag

### DIFF
--- a/benchmarks-next/run.sh
+++ b/benchmarks-next/run.sh
@@ -11,5 +11,5 @@ for BENCH_FILE in $(find $PROJECT_DIR/benchmarks-next -name benchmark.wasm); do
     BENCH_NAME=$(basename $BENCH_DIR)
 
     # Run the Wasm benchmark.
-    $SIGHTGLASS benchmark $BENCH_FILE --engine $ENGINE
+    $SIGHTGLASS benchmark $BENCH_FILE --engine $ENGINE --num-iterations 3
 done


### PR DESCRIPTION
@fitzgen, I will rebase this on #53 once that is merged and plumb it through the new structopt you added. Any preference on naming the new flag?
 1. `-r, --repeat`, this is what `perf stat` uses
 2. `-n, --num-iterations`, this is what I have currently in the PR
 3. `--samples` would be implied by #53 
 
I'm leaning toward option 2 and I would plumb it through as `--num-iterations-per-process` in the multi-process command.