### PR TITLE
Switch from perfcnt to perf-event for measuring HW counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 dependencies = [
- "libc 0.2.81",
+ "libc",
  "termion",
  "winapi 0.3.7",
 ]
@@ -80,7 +80,7 @@ dependencies = [
  "autocfg 0.1.2",
  "backtrace-sys",
  "cfg-if 0.1.7",
- "libc 0.2.81",
+ "libc",
  "rustc-demangle",
  "winapi 0.3.7",
 ]
@@ -92,7 +92,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 dependencies = [
  "cc",
- "libc 0.2.81",
+ "libc",
 ]
 
 [[package]]
@@ -116,12 +116,6 @@ name = "bencher"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
-
-[[package]]
-name = "bit_field"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
 
 [[package]]
 name = "bitflags"
@@ -153,7 +147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
 dependencies = [
  "cc",
- "libc 0.2.81",
+ "libc",
 ]
 
 [[package]]
@@ -163,7 +157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
 dependencies = [
  "brotli-sys",
- "libc 0.2.81",
+ "libc",
 ]
 
 [[package]]
@@ -218,7 +212,7 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
- "libc 0.2.81",
+ "libc",
  "num-integer",
  "num-traits",
  "time",
@@ -268,7 +262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d162c6e463c31dbf78fefa99d042156c1c74d404e299cfe3df2923cb857595b"
 dependencies = [
  "kernel32-sys",
- "libc 0.2.81",
+ "libc",
  "num_cpus",
  "winapi 0.2.8",
 ]
@@ -332,7 +326,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 dependencies = [
- "libc 0.2.81",
+ "libc",
  "redox_users",
  "winapi 0.3.7",
 ]
@@ -357,7 +351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 dependencies = [
  "errno-dragonfly",
- "libc 0.2.81",
+ "libc",
  "winapi 0.3.7",
 ]
 
@@ -368,7 +362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 dependencies = [
  "gcc",
- "libc 0.2.81",
+ "libc",
 ]
 
 [[package]]
@@ -387,7 +381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.81",
+ "libc",
  "redox_syscall",
  "winapi 0.3.7",
 ]
@@ -411,7 +405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if 0.1.7",
- "libc 0.2.81",
+ "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
@@ -468,7 +462,7 @@ dependencies = [
  "bitflags 0.7.0",
  "errno",
  "kernel32-sys",
- "libc 0.2.81",
+ "libc",
  "num",
  "pkg-config",
  "winapi 0.2.8",
@@ -512,12 +506,6 @@ name = "leb128"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
-
-[[package]]
-name = "libc"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 
 [[package]]
 name = "libc"
@@ -591,19 +579,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216929a5ee4dd316b1702eedf5e74548c123d370f47841ceaac38ca154690ca3"
 dependencies = [
  "mime",
- "phf 0.7.24",
+ "phf",
  "phf_codegen",
  "unicase",
-]
-
-[[package]]
-name = "mmap"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc85448a6006dd2ba26a385a564a8a0f1f2c7e78c70f1a70b2e0f4af286b823"
-dependencies = [
- "libc 0.1.12",
- "tempdir",
 ]
 
 [[package]]
@@ -633,16 +611,6 @@ dependencies = [
  "error-chain",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "nom"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
-dependencies = [
- "memchr",
- "version_check 0.1.5",
 ]
 
 [[package]]
@@ -687,7 +655,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
 dependencies = [
- "libc 0.2.81",
+ "libc",
 ]
 
 [[package]]
@@ -697,18 +665,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
-name = "perfcnt"
-version = "0.6.0"
+name = "perf-event"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f89cc4b06e712f0adddb96c818526f0dec372b88376ae829171bc2059ac7ac"
+checksum = "b7a1c2678a77d65edf773bd900f5b87f0944ac3421949842a2c6a4efe42d6c66"
 dependencies = [
- "bitflags 1.2.1",
- "byteorder",
- "libc 0.2.81",
- "mmap",
- "nom",
- "phf 0.8.0",
- "x86",
+ "libc",
+ "perf-event-open-sys",
+]
+
+[[package]]
+name = "perf-event-open-sys"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9bedf5da2c234fdf2391ede2b90fabf585355f33100689bc364a3ea558561a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -717,16 +689,7 @@ version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
 dependencies = [
- "phf_shared 0.7.24",
-]
-
-[[package]]
-name = "phf"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
-dependencies = [
- "phf_shared 0.8.0",
+ "phf_shared",
 ]
 
 [[package]]
@@ -736,7 +699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
 dependencies = [
  "phf_generator",
- "phf_shared 0.7.24",
+ "phf_shared",
 ]
 
 [[package]]
@@ -745,7 +708,7 @@ version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 dependencies = [
- "phf_shared 0.7.24",
+ "phf_shared",
  "rand 0.6.5",
 ]
 
@@ -755,17 +718,8 @@ version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 dependencies = [
- "siphasher 0.2.3",
+ "siphasher",
  "unicase",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
-dependencies = [
- "siphasher 0.3.3",
 ]
 
 [[package]]
@@ -793,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d800f775685df7c29c60971217bcfb908bd98c807ce8346cba9fe77df9a9dcc"
 dependencies = [
  "cc",
- "libc 0.2.81",
+ "libc",
  "rustc_version",
 ]
 
@@ -886,7 +840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc 0.2.81",
+ "libc",
  "rand_core 0.3.1",
  "rdrand",
  "winapi 0.3.7",
@@ -900,7 +854,7 @@ checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 dependencies = [
  "cloudabi",
  "fuchsia-cprng",
- "libc 0.2.81",
+ "libc",
  "rand_core 0.3.1",
  "winapi 0.3.7",
 ]
@@ -912,7 +866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
  "autocfg 0.1.2",
- "libc 0.2.81",
+ "libc",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
  "rand_hc 0.1.0",
@@ -931,7 +885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
- "libc 0.2.81",
+ "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
@@ -1015,7 +969,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
- "libc 0.2.81",
+ "libc",
  "rand_core 0.4.2",
  "winapi 0.3.7",
 ]
@@ -1028,7 +982,7 @@ checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
  "cloudabi",
  "fuchsia-cprng",
- "libc 0.2.81",
+ "libc",
  "rand_core 0.4.2",
  "rdrand",
  "winapi 0.3.7",
@@ -1060,17 +1014,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "8.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdf7d9dbd43f3d81d94a49c1c3df73cc2b3827995147e6cf7f89d4ec5483e73"
-dependencies = [
- "bitflags 1.2.1",
- "cc",
- "rustc_version",
 ]
 
 [[package]]
@@ -1301,7 +1244,7 @@ dependencies = [
  "core_affinity",
  "goblin",
  "hwloc",
- "libc 0.2.81",
+ "libc",
  "libloading 0.5.0",
  "precision",
  "printtable",
@@ -1351,7 +1294,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libloading 0.6.6",
  "log 0.4.11",
- "perfcnt",
+ "perf-event",
  "precision",
  "pretty_env_logger",
  "serde",
@@ -1365,12 +1308,6 @@ name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
-
-[[package]]
-name = "siphasher"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 
 [[package]]
 name = "strsim"
@@ -1460,7 +1397,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 dependencies = [
- "libc 0.2.81",
+ "libc",
  "redox_syscall",
  "redox_termios",
 ]
@@ -1518,7 +1455,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
- "libc 0.2.81",
+ "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.7",
 ]
@@ -1743,18 +1680,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "x86"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c146cbc47471e076987378c159a7aa8fa434680c6fbddca59fe6f40f1591c819"
-dependencies = [
- "bit_field",
- "bitflags 1.2.1",
- "csv",
- "phf 0.7.24",
- "phf_codegen",
- "raw-cpuid",
- "serde_json",
-]

--- a/crates/recorder/Cargo.toml
+++ b/crates/recorder/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0"
 cfg-if = "1.0"
 libloading = "0.6"
 log = "0.4"
-perfcnt = "0.6"
+perf-event = "0.4"
 precision = "0.1"
 serde = { version = "1.0.118", features = ["derive"] }
 sightglass-artifact = { path = "../artifact" }

--- a/crates/recorder/src/measure/counters.rs
+++ b/crates/recorder/src/measure/counters.rs
@@ -1,172 +1,87 @@
-//! A mechanism to measure performance using CPU counters through `perf_event_open`.
-//!
-//! This code is lightly adapted from iximeow's work in
-//! https://github.com/bytecodealliance/sightglass/pull/31.
+//! A mechanism to measure performance using CPU counters through `perf_event_open`. For this to
+//! work (and it will only work on Linux systems currently), you may need to tweak
+//! `/proc/sys/kernel/perf_event_paranoid` by running a command such as: `sudo sysctl -w
+//! kernel.perf_event_paranoid=0`.
 use super::{Measure, Measurement};
-use perfcnt::{AbstractPerfCounter, PerfCounter};
-use precision::{Precision, Timestamp};
+use perf_event::{events::Hardware, Builder, Counter, Group};
 use serde::{Deserialize, Serialize};
 
 /// Measure CPU counters.
 pub struct CounterMeasure {
-    precision: Precision,
-    start_time: Option<Timestamp>,
-    cpu_cycles: Option<PerfCounter>,
-    instructions_retired: Option<PerfCounter>,
-    cache_accesses: Option<PerfCounter>,
-    cache_misses: Option<PerfCounter>,
+    event_group: Group,
+    cpu_cycles: Counter,
+    instructions_retired: Counter,
+    cache_accesses: Counter,
+    cache_misses: Counter,
 }
 
 impl CounterMeasure {
-    cfg_if::cfg_if! {
-        if #[cfg(target_os = "linux")] {
-            pub fn new() -> Self {
-                use perfcnt::linux::HardwareEventType;
-                let precision = Precision::new(precision::Config::default()).expect("to create a precision object");
-                Self {
-                    precision,
-                    start_time: None,
-                    cpu_cycles: linux::create_hardware_counter(HardwareEventType::CPUCycles),
-                    instructions_retired: linux::create_hardware_counter(HardwareEventType::Instructions),
-                    cache_accesses: linux::create_hardware_counter(HardwareEventType::CacheReferences),
-                    cache_misses: linux::create_hardware_counter(HardwareEventType::CacheMisses)
-                }
-            }
-        } else {
-            pub fn new() -> Self {
-                let precision = Precision::new(precision::Config::default()).expect("to create a precision object");
-                // This doesn't currently support performance counter use on non-linux targets.
-                // `perfcnt` doesn't feature-gate `linux` so explicitly provide None's here rather
-                // than calling possibly wildly incorrect syscalls on non-linux targets.
-                Self {
-                    precision,
-                    start_time: None,
-                    cpu_cycles: None,
-                    instructions_retired: None,
-                    cache_accesses: None,
-                    cache_misses: None,
-                }
-            }
+    #[cfg(target_os = "linux")]
+    pub fn new() -> Self {
+        let mut group = Group::new().expect(
+            "Unable to create event group; try setting /proc/sys/kernel/perf_event_paranoid to 2 \
+            or below?",
+        );
+        Self {
+            cpu_cycles: Builder::new()
+                .group(&mut group)
+                .kind(Hardware::CPU_CYCLES)
+                .build()
+                .expect(
+                    "Unable to create CPU_CYCLES hardware counter. Does this system actually \
+                have such a counter? If it does, your kernel may not fully support this processor.",
+                ),
+            instructions_retired: Builder::new()
+                .group(&mut group)
+                .kind(Hardware::INSTRUCTIONS)
+                .build()
+                .expect(
+                    "Unable to create INSTRUCTIONS hardware counter. Does this system actually \
+                    have such a counter? If it does, your kernel may not fully support this \
+                processor.",
+                ),
+            cache_accesses: Builder::new()
+                .group(&mut group)
+                .kind(Hardware::CACHE_REFERENCES)
+                .build()
+                .expect(
+                    "Unable to create CACHE_REFERENCES hardware counter. Does this system actually \
+                have such a counter? If it does, your kernel may not fully support this processor.",
+                ),
+            cache_misses: Builder::new()
+                .group(&mut group)
+                .kind(Hardware::CACHE_MISSES)
+                .build()
+                .expect(
+                    "Unable to create CACHE_MISSES hardware counter. Does this system actually \
+                have such a counter? If it does, your kernel may not fully support this processor.",
+                ),
+            event_group: group,
         }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn new() -> Self {
+        // This Measure doesn't currently support performance counter use on non-linux
+        // targets but it could in the future.
+        unimplemented!("`perf_event_open` is only available on Linux systems");
     }
 }
 
-/// TODO the counter measurements should be grouped to avoid noise from calling ioctl once for each
-/// reset/start/stop; see https://github.com/gz/rust-perfcnt/issues/19 and discussion at
-/// https://github.com/bytecodealliance/sightglass/pull/31#discussion_r459794132.
 impl Measure for CounterMeasure {
     fn start(&mut self) {
-        if let Some(cpu_cycle_counter) = self.cpu_cycles.as_mut() {
-            cpu_cycle_counter
-                .reset()
-                .expect("if a counter could be created, it can be reset");
-        }
-        if let Some(instructions_retired) = self.instructions_retired.as_mut() {
-            instructions_retired
-                .reset()
-                .expect("if a counter could be created, it can be reset");
-        }
-        if let Some(cache_accesses) = self.cache_accesses.as_mut() {
-            cache_accesses
-                .reset()
-                .expect("if a counter could be created, it can be reset");
-        }
-        if let Some(cache_misses) = self.cache_misses.as_mut() {
-            cache_misses
-                .reset()
-                .expect("if a counter could be created, it can be reset");
-        }
-
-        // Start the wall clock last to avoid measuring effects of `perf_event_open` (?).
-        self.start_time = Some(self.precision.now());
+        self.event_group.enable().unwrap()
     }
 
     fn end(&mut self) -> Measurement {
-        let time_end = self.precision.now();
+        self.event_group.disable().unwrap();
+        let counts = self.event_group.read().unwrap();
         Measurement::PerfCounters(PerfCounters {
-            clock_time: (time_end - self.start_time.unwrap()).ticks(),
-            cpu_cycles: self
-                .cpu_cycles
-                .as_mut()
-                .and_then(|c| c.read().ok())
-                .unwrap_or(0),
-            instructions_retired: self
-                .instructions_retired
-                .as_mut()
-                .and_then(|c| c.read().ok())
-                .unwrap_or(0),
-            cache_accesses: self
-                .cache_accesses
-                .as_mut()
-                .and_then(|c| c.read().ok())
-                .unwrap_or(0),
-            cache_misses: self
-                .cache_misses
-                .as_mut()
-                .and_then(|c| c.read().ok())
-                .unwrap_or(0),
+            cpu_cycles: counts[&self.cpu_cycles],
+            instructions_retired: counts[&self.instructions_retired],
+            cache_accesses: counts[&self.cache_accesses],
+            cache_misses: counts[&self.cache_misses],
         })
-    }
-}
-
-#[cfg(target_os = "linux")]
-mod linux {
-    use perfcnt::linux::{HardwareEventType, PerfCounterBuilderLinux};
-    use perfcnt::PerfCounter;
-
-    fn hardware_event_name(counter_type: &HardwareEventType) -> &'static str {
-        match counter_type {
-            HardwareEventType::CPUCycles => "CPUCycles",
-            HardwareEventType::Instructions => "Instructions",
-            HardwareEventType::CacheReferences => "CacheReferences",
-            HardwareEventType::CacheMisses => "CacheMisses",
-            HardwareEventType::BranchInstructions => "BranchInstructions",
-            HardwareEventType::BranchMisses => "BranchMisses",
-            HardwareEventType::BusCycles => "BusCycles",
-            HardwareEventType::StalledCyclesFrontend => "StalledCyclesFrontend",
-            HardwareEventType::StalledCyclesBackend => "StalledCyclesBackend",
-            HardwareEventType::RefCPUCycles => "RefCPUCycles",
-        }
-    }
-
-    // Errors in initializing performance counters are probably not fatal. For some kinds of
-    // errors, we can give a useful hint if someone is looking at stderr. Either way, we can
-    // continue on with None where the only data recorded is some form of timer.
-    pub fn create_hardware_counter(counter_type: HardwareEventType) -> Option<PerfCounter> {
-        // `HardwareEventType` is neither Clone nor Debug. In case we need a name for this counter
-        // later, get it ready here.
-        let event_name = hardware_event_name(&counter_type);
-        let counter = PerfCounterBuilderLinux::from_hardware_event(counter_type)
-            .on_all_cpus()
-            .for_pid(0) // 0 means "the current PID"
-            .enable_read_format_time_enabled()
-            .enable_read_format_time_running()
-            .enable_read_format_id()
-            .finish();
-        match counter {
-            Err(e) => {
-                match e.kind() {
-                    std::io::ErrorKind::PermissionDenied => {
-                        // Linux appears to support an undocumented level "3" for
-                        // `perf_event_paranoid`, denying the ability to use perf to inspect the
-                        // current process.
-                        eprintln!("Permission denied for hardware event {}. Try setting /proc/sys/kernel/perf_event_paranoid to 2 or below?", event_name);
-                    }
-                    std::io::ErrorKind::NotFound => {
-                        eprintln!(
-                            "Unable to create hardware counter for {}. Does this system actually have such a counter? If it does, your kernel may not fully support this processor.", event_name);
-                    }
-                    _ => {
-                        eprintln!(
-                            "Unknown error encountered when creating hardware counter for {}: {:?}",
-                            event_name, e
-                        );
-                    }
-                };
-                None
-            }
-            Ok(counter) => Some(counter),
-        }
     }
 }
 
@@ -174,8 +89,6 @@ mod linux {
 /// useful zero to accumulate into.
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 pub struct PerfCounters {
-    /// The wall clock time (in CPU cycles) that passed while measuring this sample.
-    pub clock_time: u64,
     /// Measured by performance counter. May be 0, in which case the counter is almost certainly
     /// disabled.
     pub cpu_cycles: u64,
@@ -190,13 +103,10 @@ pub struct PerfCounters {
     pub cache_misses: u64,
 }
 
-// impl Measurement for CounterMeasurement {}
-
 impl std::ops::Div<u64> for PerfCounters {
     type Output = Self;
     fn div(self, rhs: u64) -> Self::Output {
         PerfCounters {
-            clock_time: self.clock_time / rhs,
             cpu_cycles: self.cpu_cycles / rhs,
             instructions_retired: self.instructions_retired / rhs,
             cache_accesses: self.cache_accesses / rhs,
@@ -209,7 +119,6 @@ impl std::ops::Add<PerfCounters> for PerfCounters {
     type Output = Self;
     fn add(self, rhs: PerfCounters) -> Self::Output {
         PerfCounters {
-            clock_time: self.clock_time + rhs.clock_time,
             cpu_cycles: self.cpu_cycles + rhs.cpu_cycles,
             instructions_retired: self.instructions_retired + rhs.instructions_retired,
             cache_accesses: self.cache_accesses + rhs.cache_accesses,
@@ -220,10 +129,40 @@ impl std::ops::Add<PerfCounters> for PerfCounters {
 
 impl std::ops::AddAssign<PerfCounters> for PerfCounters {
     fn add_assign(&mut self, rhs: PerfCounters) {
-        self.clock_time += rhs.clock_time;
         self.cpu_cycles += rhs.cpu_cycles;
         self.instructions_retired += rhs.instructions_retired;
         self.cache_accesses += rhs.cache_accesses;
         self.cache_misses += rhs.cache_misses;
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn sanity() {
+        if env::var("CI").is_ok() {
+            // If we find ourselves in a CI environment, skip this test: not all CI environments
+            // have perf events available (e.g. https://github.community/t/149164). Since this
+            // short-circuiting could be problematic in the future, we attempt to warn the user
+            // (hoping they have `--nocapture` set).
+            println!(
+                "Skipping the perf counters sanity test; it seems that this test is running \
+                in a CI environment"
+            );
+            return;
+        }
+
+        let mut measure = CounterMeasure::new();
+        measure.start();
+        let mut a = 0;
+        for i in 0..1_000_000 {
+            a = i
+        }
+        let measurement = measure.end();
+        println!("Result: {}", a);
+        println!("Measurement: {:?}", measurement);
     }
 }


### PR DESCRIPTION
Since `perfcnt` still lacks support for grouping perf event counters (see https://github.com/gz/rust-perfcnt/issues/19), this change switches to using `perf-event`, which does.