### PR TITLE
Run benchmarks during CI to verify benchmark-running still works

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,36 @@
+name: benchmarks
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_LOG: info
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+    - name: Rebuild benchmarks
+      run: benchmarks-next/build.sh
+    - name: Verify no benchmarks have changed
+      run: git diff --no-ext-diff --name-only --exit-code
+
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+    - name: Run benchmarks
+      run: benchmarks-next/run.sh

--- a/.github/workflows/sightglass.yml
+++ b/.github/workflows/sightglass.yml
@@ -23,16 +23,3 @@ jobs:
       run: cargo +nightly build --verbose --all
     - name: Test all
       run: cargo +nightly test --verbose --all
-
-  rebuild_benchmarks:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install nightly
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-    - name: Rebuild benchmarks
-      run: benchmarks-next/build.sh
-    - name: Verify no benchmarks have changed
-      run: git diff --no-ext-diff --name-only --exit-code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "cd5a90e2b463010cd0e0ce9a11d4a9d5d58d9f41d4a6ba3dcaf9e68b466e88b4"
 dependencies = [
  "autocfg 0.1.2",
  "backtrace-sys",
- "cfg-if 0.1.7",
+ "cfg-if 0.1.10",
  "libc",
  "rustc-demangle",
  "winapi 0.3.7",
@@ -141,6 +141,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ff35b701f3914bdb8fad3368d822c766ef2858b2583198e41639b936f09d3f"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 0.1.10",
+ "constant_time_eq",
+ "crypto-mac",
+ "digest",
+]
+
+[[package]]
 name = "brotli-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,9 +211,9 @@ checksum = "30f813bf45048a18eda9190fd3c6b78644146056740c43172a5a3699118588fd"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.7"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -288,6 +303,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,10 +346,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
  "libc",
  "redox_users",
@@ -399,12 +453,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check 0.9.2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if 0.1.7",
+ "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -548,7 +612,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if 0.1.7",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -1260,6 +1324,8 @@ name = "sightglass-artifact"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "blake3",
+ "dirs 3.0.1",
  "log 0.4.11",
  "pretty_env_logger",
  "serde",
@@ -1339,6 +1405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+
+[[package]]
 name = "syn"
 version = "0.15.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,7 +1449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
- "dirs",
+ "dirs 1.0.5",
  "winapi 0.3.7",
 ]
 
@@ -1504,6 +1576,12 @@ checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unicase"

--- a/benchmarks-next/build.sh
+++ b/benchmarks-next/build.sh
@@ -14,5 +14,5 @@ for DOCKERFILE in $(find $PROJECT_DIR/benchmarks-next -name Dockerfile); do
     cp $PROJECT_DIR/include/sightglass-next.h $BENCH_DIR/sightglass.h
 
     # Build the Wasm benchmark.
-    $SIGHTGLASS build $DOCKERFILE -d $BENCH_DIR/benchmark.wasm --emit-wat
+    $SIGHTGLASS build-benchmark $DOCKERFILE -d $BENCH_DIR/benchmark.wasm --emit-wat
 done

--- a/benchmarks-next/run.sh
+++ b/benchmarks-next/run.sh
@@ -3,13 +3,13 @@
 set -e
 PROJECT_DIR=$(dirname "$0" | xargs dirname)
 SIGHTGLASS="cargo +nightly run --bin sightglass-cli --"
-ENGINE=$(realpath $PROJECT_DIR/../wasmtime/target/debug/libwasmtime_bench_api.so)
 export RUST_LOG=debug
 
+$SIGHTGLASS build-engine wasmtime
 for BENCH_FILE in $(find $PROJECT_DIR/benchmarks-next -name benchmark.wasm); do
     BENCH_DIR=$(dirname $BENCH_FILE)
     BENCH_NAME=$(basename $BENCH_DIR)
 
     # Run the Wasm benchmark.
-    $SIGHTGLASS benchmark $BENCH_FILE --engine $ENGINE --num-iterations 3
+    $SIGHTGLASS in-process-benchmark --engine wasmtime --num-iterations 3 $BENCH_FILE
 done

--- a/crates/artifact/Cargo.toml
+++ b/crates/artifact/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+blake3 = "0.3"
+dirs = "3.0"
 log = "0.4"
 serde = { version = "1.0.118", features = ["derive"] }
 thiserror = "1.0"

--- a/crates/artifact/src/engine.rs
+++ b/crates/artifact/src/engine.rs
@@ -1,0 +1,239 @@
+use crate::{docker::DockerError, DockerBuildArgs, Dockerfile, GitLocation};
+use dirs::home_dir;
+use log;
+use std::{fmt, fs, path::PathBuf, str::FromStr};
+use thiserror::Error;
+
+/// Abstracts the artifact that implements the Wasm benchmarking engine. This provides the
+/// functionality for finding engine artifacts (i.e. shared libraries) and building them from
+/// Dockerfiles; eventually it should be combined with sightglass-recorder's Engine structure.
+#[derive(Debug)]
+pub enum Engine {
+    // An engine specified by its engine-ref: e.g. `wasmtime`, `wasmtime@8273ba32`,
+    // `wasmtime@some-branch@https://github.com/user/wasmtime`
+    EngineRef(EngineRef),
+    // An engine specified by its location in the file system.
+    LibraryPath(PathBuf),
+}
+impl Engine {
+    /// Calculate the path to the engine library.
+    pub fn path(&self) -> PathBuf {
+        match self {
+            Self::EngineRef(e) => Self::get_library_location(&e.to_string()),
+            Self::LibraryPath(p) => p.clone(),
+        }
+    }
+
+    /// Check if the engine library exists.
+    pub fn exists(&self) -> bool {
+        self.path().is_file()
+    }
+
+    /// If the engine is a reference, build it.
+    pub fn build(&self) -> Result<(), EngineError> {
+        log::info!("Building engine: {:?}", self);
+        if let Self::EngineRef(e) = self {
+            EngineBuilder::from(e.clone()).build()?; // TODO this is a bit backwards: we extract the engine-ref only to recreate engine
+            assert!(self.exists());
+            Ok(())
+        } else {
+            Err(EngineError::CannotBuildEnginePath)
+        }
+    }
+
+    /// Calculate the default location of an engine's shared library based on a unique slug.
+    fn get_library_location(slug: &str) -> PathBuf {
+        let mut p = home_dir().expect("a home directory to be present");
+        p.push(".sightglass");
+        p.push(slug);
+        if !p.is_dir() {
+            fs::create_dir_all(&p).expect("to create the sightglass directory");
+        }
+        p.push("engine.so"); // TODO the `.so` is too platform-specific.
+        p
+    }
+}
+impl FromStr for Engine {
+    type Err = EngineError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match EngineRef::from_str(s) {
+            Ok(l) => Ok(Self::EngineRef(l)),
+            Err(_) => Ok(Self::LibraryPath(PathBuf::from(s))),
+        }
+    }
+}
+impl fmt::Display for Engine {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EngineRef(e) => write!(f, "{}", e),
+            Self::LibraryPath(p) => write!(f, "{}", p.display()),
+        }
+    }
+}
+impl From<EngineRef> for Engine {
+    fn from(e: EngineRef) -> Engine {
+        Engine::EngineRef(e)
+    }
+}
+impl From<&Dockerfile> for Engine {
+    fn from(e: &Dockerfile) -> Engine {
+        Engine::LibraryPath(Self::get_library_location(&e.to_string()))
+    }
+}
+
+/// Describes the ways an engine can be built. Either we have well-known Dockerfiles that
+/// parameterized for different repositories and revisions or we build from a Dockerfile directly.
+#[derive(Debug)]
+pub enum EngineBuilder {
+    /// The name and, optionally, a Git location path to a Dockerfile that will build a benchmark engine.
+    WellKnown(EngineRef),
+    /// The path to a Dockerfile that will build a benchmark engine.
+    Dockerfile(Dockerfile),
+}
+impl EngineBuilder {
+    /// Return the expected source location of a benchmark engine inside a Docker image. TODO this
+    /// is too platform-specific.
+    pub fn source() -> PathBuf {
+        PathBuf::from("/engine.so")
+    }
+
+    /// Build an engine library using Docker.
+    pub fn build(&self) -> Result<Engine, EngineError> {
+        log::info!("Building engine from builder: {:?}", self);
+        let engine = self.as_engine();
+        let (dockerfile, args) = self.as_dockerfile();
+        dockerfile.extract(Self::source(), engine.path(), args)?;
+        Ok(engine)
+    }
+
+    /// Create an engine instance from this builder.
+    pub fn as_engine(&self) -> Engine {
+        match self {
+            Self::WellKnown(location) => Engine::from(location.clone()),
+            Self::Dockerfile(dockerfile) => Engine::from(dockerfile),
+        }
+    }
+
+    /// Find the Dockerfile used for building this engine.
+    fn as_dockerfile(&self) -> (Dockerfile, Option<DockerBuildArgs>) {
+        match self {
+            Self::WellKnown(location) => {
+                // Find the path to the well-known Dockerfile.
+                let mut path = PathBuf::from("."); // TODO calculate the project directory
+                path.push("engines");
+                path.push(&location.engine.to_string());
+                path.push("Dockerfile");
+                let dockerfile = Dockerfile::from(path);
+
+                // Set up any additional arguments for building the library.
+                let mut args = DockerBuildArgs::new();
+                if let Some(revision) = &location.git.revision {
+                    args.set("REVISION".to_string(), revision.clone())
+                }
+                if let Some(repository) = &location.git.repository {
+                    args.set("REPOSITORY".to_string(), repository.clone())
+                }
+
+                (dockerfile, Some(args))
+            }
+            Self::Dockerfile(dockerfile) => (dockerfile.clone(), None),
+        }
+    }
+}
+impl FromStr for EngineBuilder {
+    type Err = EngineError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match EngineRef::from_str(s) {
+            Ok(l) => Ok(Self::WellKnown(l)),
+            Err(_) => Ok(Self::Dockerfile(Dockerfile::from(PathBuf::from(s)))),
+        }
+    }
+}
+impl From<EngineRef> for EngineBuilder {
+    fn from(e: EngineRef) -> EngineBuilder {
+        EngineBuilder::WellKnown(e)
+    }
+}
+
+/// An engine-ref is a parseable description of a benchmarking engine. This crate understands how to
+/// build certain well-known engines.
+#[derive(Clone, Debug)]
+pub struct EngineRef {
+    engine: WellKnownEngine,
+    git: GitLocation,
+}
+impl fmt::Display for EngineRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.engine)?;
+        if let Some(rev) = &self.git.revision {
+            write!(f, "@{}", rev)?;
+        }
+        if let Some(repo) = &self.git.repository {
+            write!(f, "@{}", repo)?;
+        }
+        Ok(())
+    }
+}
+impl FromStr for EngineRef {
+    type Err = EngineError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<_> = s.split('@').collect();
+        let engine = if let Some(name) = parts.get(0) {
+            name.parse()?
+        } else {
+            return Err(EngineError::EmptyEngineRef);
+        };
+        let revision = parts.get(1).map(|s| s.to_string());
+        let repository = parts.get(2).map(|s| s.to_string());
+        if parts.len() > 3 {
+            return Err(EngineError::TooLargeEngineRef);
+        }
+        Ok(Self {
+            engine,
+            git: GitLocation {
+                repository,
+                revision,
+            },
+        })
+    }
+}
+
+/// Enumerates the engines known to sightglass.
+#[derive(Clone, Debug)]
+pub enum WellKnownEngine {
+    Wasmtime,
+}
+impl fmt::Display for WellKnownEngine {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Wasmtime => "wasmtime",
+        };
+        write!(f, "{}", s)
+    }
+}
+impl FromStr for WellKnownEngine {
+    type Err = EngineError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "wasmtime" => Ok(Self::Wasmtime),
+            _ => Err(EngineError::UnknownEngine(s.to_string())),
+        }
+    }
+}
+
+/// Describe the ways this module can fail.
+#[derive(Debug, Error)]
+pub enum EngineError {
+    #[error("unknown engine: {0}")]
+    UnknownEngine(String),
+    #[error("the engine-ref must not be empty")]
+    EmptyEngineRef,
+    #[error(
+        "an engine-ref must not have more than 3 parts: [engine name]@[revision]@[repository]"
+    )]
+    TooLargeEngineRef,
+    #[error("the engine is specified by a path that is not buildable; use an engine-ref instead")]
+    CannotBuildEnginePath,
+    #[error("failed to build engine in Docker")]
+    FailedBuild(#[from] DockerError),
+}

--- a/crates/artifact/src/engine.rs
+++ b/crates/artifact/src/engine.rs
@@ -1,158 +1,94 @@
-use crate::{docker::DockerError, DockerBuildArgs, Dockerfile, GitLocation};
-use dirs::home_dir;
+use crate::{DockerBuildArgs, Dockerfile, GitLocation};
+use anyhow::{anyhow, Result};
+use dirs;
 use log;
-use std::{fmt, fs, path::PathBuf, str::FromStr};
-use thiserror::Error;
+use std::{env, fmt, fs, path::Path, path::PathBuf, str::FromStr};
 
-/// Abstracts the artifact that implements the Wasm benchmarking engine. This provides the
-/// functionality for finding engine artifacts (i.e. shared libraries) and building them from
-/// Dockerfiles; eventually it should be combined with sightglass-recorder's Engine structure.
-#[derive(Debug)]
-pub enum Engine {
-    // An engine specified by its engine-ref: e.g. `wasmtime`, `wasmtime@8273ba32`,
-    // `wasmtime@some-branch@https://github.com/user/wasmtime`
-    EngineRef(EngineRef),
-    // An engine specified by its location in the file system.
-    LibraryPath(PathBuf),
+// Retrieve a built engine library for running benchmarks; the returned value is a path to the built
+// engine's dylib. This function will attempt to build the library if it does not yet exist.
+pub fn get_built_engine(engine: &str) -> Result<PathBuf> {
+    if Path::new(engine).exists() {
+        log::debug!("Using already-built engine path: {}", engine);
+        return Ok(PathBuf::from(engine));
+    }
+
+    // Get the path to where the known engine dylib would be if it is built, or else propagate an
+    // unknown engine error.
+    let engine_path = get_known_engine_path(engine)?;
+
+    // If no file exists at the engine path, then we have to build it.
+    if !engine_path.exists() {
+        build_engine(engine, &engine_path)?;
+        assert!(engine_path.exists());
+    }
+
+    log::debug!("Using known engine at path: {}", engine_path.display());
+    Ok(engine_path)
 }
-impl Engine {
-    /// Calculate the path to the engine library.
-    pub fn path(&self) -> PathBuf {
-        match self {
-            Self::EngineRef(e) => Self::get_library_location(&e.to_string()),
-            Self::LibraryPath(p) => p.clone(),
+
+/// Calculate the path to an engine library: e.g. `<user's app data
+/// dir>/sightglass/wasmtime@ab1234ef/libengine.so`.
+pub fn get_known_engine_path(slug: &str) -> Result<PathBuf> {
+    let mut p = dirs::data_local_dir().ok_or(anyhow!(
+        "missing an application data folder for storing sightglass engines; e.g. \
+        /home/.../.local/share, C:\\Users\\...\\AppData\\Local"
+    ))?;
+    p.push("sightglass");
+    p.push(slug);
+    p.push(get_engine_filename());
+    Ok(p)
+}
+
+/// Calculate the library name for a sightglass library on the target operating system: e.g.
+/// `engine.dll`, `libengine.so`.
+pub fn get_engine_filename() -> String {
+    format!(
+        "{}engine{}",
+        env::consts::DLL_PREFIX,
+        env::consts::DLL_SUFFIX
+    )
+}
+
+/// Calculate the path to the Dockerfile for building a known engine.
+pub fn get_known_dockerfile_path(slug: &str) -> Result<PathBuf> {
+    let mut path = PathBuf::from("."); // TODO calculate the project directory
+    path.push("engines");
+    path.push(slug);
+    path.push("Dockerfile");
+    Ok(path)
+}
+
+/// Build an engine from either a Dockerfile or a known engine.
+pub fn build_engine(engine: &str, engine_path: &Path) -> Result<()> {
+    // If the known engine's directory is not yet created, create it.
+    let engine_dir = engine_path.parent().unwrap();
+    if !engine_dir.is_dir() {
+        fs::create_dir_all(&engine_dir)?;
+        log::debug!("Created sightglass directory: {}", engine_dir.display());
+    }
+
+    let (dockerfile, args) = if Path::new(engine).exists() {
+        (Dockerfile::from(PathBuf::from(engine)), None)
+    } else {
+        let engine_ref = EngineRef::from_str(engine)?;
+        let dockerfile =
+            Dockerfile::from(get_known_dockerfile_path(&engine_ref.engine.to_string())?);
+
+        // Set up any additional arguments for building the library.
+        let mut args = DockerBuildArgs::new();
+        if let Some(revision) = &engine_ref.git.revision {
+            args.set("REVISION".to_string(), revision.clone())
         }
-    }
-
-    /// Check if the engine library exists.
-    pub fn exists(&self) -> bool {
-        self.path().is_file()
-    }
-
-    /// If the engine is a reference, build it.
-    pub fn build(&self) -> Result<(), EngineError> {
-        log::info!("Building engine: {:?}", self);
-        if let Self::EngineRef(e) = self {
-            EngineBuilder::from(e.clone()).build()?; // TODO this is a bit backwards: we extract the engine-ref only to recreate engine
-            assert!(self.exists());
-            Ok(())
-        } else {
-            Err(EngineError::CannotBuildEnginePath)
+        if let Some(repository) = &engine_ref.git.repository {
+            args.set("REPOSITORY".to_string(), repository.clone())
         }
-    }
 
-    /// Calculate the default location of an engine's shared library based on a unique slug.
-    fn get_library_location(slug: &str) -> PathBuf {
-        let mut p = home_dir().expect("a home directory to be present");
-        p.push(".sightglass");
-        p.push(slug);
-        if !p.is_dir() {
-            fs::create_dir_all(&p).expect("to create the sightglass directory");
-        }
-        p.push("engine.so"); // TODO the `.so` is too platform-specific.
-        p
-    }
-}
-impl FromStr for Engine {
-    type Err = EngineError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match EngineRef::from_str(s) {
-            Ok(l) => Ok(Self::EngineRef(l)),
-            Err(_) => Ok(Self::LibraryPath(PathBuf::from(s))),
-        }
-    }
-}
-impl fmt::Display for Engine {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::EngineRef(e) => write!(f, "{}", e),
-            Self::LibraryPath(p) => write!(f, "{}", p.display()),
-        }
-    }
-}
-impl From<EngineRef> for Engine {
-    fn from(e: EngineRef) -> Engine {
-        Engine::EngineRef(e)
-    }
-}
-impl From<&Dockerfile> for Engine {
-    fn from(e: &Dockerfile) -> Engine {
-        Engine::LibraryPath(Self::get_library_location(&e.to_string()))
-    }
-}
+        (dockerfile, Some(args))
+    };
 
-/// Describes the ways an engine can be built. Either we have well-known Dockerfiles that
-/// parameterized for different repositories and revisions or we build from a Dockerfile directly.
-#[derive(Debug)]
-pub enum EngineBuilder {
-    /// The name and, optionally, a Git location path to a Dockerfile that will build a benchmark engine.
-    WellKnown(EngineRef),
-    /// The path to a Dockerfile that will build a benchmark engine.
-    Dockerfile(Dockerfile),
-}
-impl EngineBuilder {
-    /// Return the expected source location of a benchmark engine inside a Docker image. TODO this
-    /// is too platform-specific.
-    pub fn source() -> PathBuf {
-        PathBuf::from("/engine.so")
-    }
-
-    /// Build an engine library using Docker.
-    pub fn build(&self) -> Result<Engine, EngineError> {
-        log::info!("Building engine from builder: {:?}", self);
-        let engine = self.as_engine();
-        let (dockerfile, args) = self.as_dockerfile();
-        dockerfile.extract(Self::source(), engine.path(), args)?;
-        Ok(engine)
-    }
-
-    /// Create an engine instance from this builder.
-    pub fn as_engine(&self) -> Engine {
-        match self {
-            Self::WellKnown(location) => Engine::from(location.clone()),
-            Self::Dockerfile(dockerfile) => Engine::from(dockerfile),
-        }
-    }
-
-    /// Find the Dockerfile used for building this engine.
-    fn as_dockerfile(&self) -> (Dockerfile, Option<DockerBuildArgs>) {
-        match self {
-            Self::WellKnown(location) => {
-                // Find the path to the well-known Dockerfile.
-                let mut path = PathBuf::from("."); // TODO calculate the project directory
-                path.push("engines");
-                path.push(&location.engine.to_string());
-                path.push("Dockerfile");
-                let dockerfile = Dockerfile::from(path);
-
-                // Set up any additional arguments for building the library.
-                let mut args = DockerBuildArgs::new();
-                if let Some(revision) = &location.git.revision {
-                    args.set("REVISION".to_string(), revision.clone())
-                }
-                if let Some(repository) = &location.git.repository {
-                    args.set("REPOSITORY".to_string(), repository.clone())
-                }
-
-                (dockerfile, Some(args))
-            }
-            Self::Dockerfile(dockerfile) => (dockerfile.clone(), None),
-        }
-    }
-}
-impl FromStr for EngineBuilder {
-    type Err = EngineError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match EngineRef::from_str(s) {
-            Ok(l) => Ok(Self::WellKnown(l)),
-            Err(_) => Ok(Self::Dockerfile(Dockerfile::from(PathBuf::from(s)))),
-        }
-    }
-}
-impl From<EngineRef> for EngineBuilder {
-    fn from(e: EngineRef) -> EngineBuilder {
-        EngineBuilder::WellKnown(e)
-    }
+    log::debug!("Using Dockerfile at path: {}", dockerfile);
+    dockerfile.extract(format!("/{}", get_engine_filename()), engine_path, args)?;
+    Ok(())
 }
 
 /// An engine-ref is a parseable description of a benchmarking engine. This crate understands how to
@@ -175,18 +111,20 @@ impl fmt::Display for EngineRef {
     }
 }
 impl FromStr for EngineRef {
-    type Err = EngineError;
+    type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let parts: Vec<_> = s.split('@').collect();
         let engine = if let Some(name) = parts.get(0) {
             name.parse()?
         } else {
-            return Err(EngineError::EmptyEngineRef);
+            return Err(anyhow!(
+                "failed to parse engine-ref; the engine-ref must not be empty"
+            ));
         };
         let revision = parts.get(1).map(|s| s.to_string());
         let repository = parts.get(2).map(|s| s.to_string());
         if parts.len() > 3 {
-            return Err(EngineError::TooLargeEngineRef);
+            return Err(anyhow!("an engine-ref must not have more than 3 parts: [engine name]@[revision]@[repository]"));
         }
         Ok(Self {
             engine,
@@ -212,28 +150,49 @@ impl fmt::Display for WellKnownEngine {
     }
 }
 impl FromStr for WellKnownEngine {
-    type Err = EngineError;
+    type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "wasmtime" => Ok(Self::Wasmtime),
-            _ => Err(EngineError::UnknownEngine(s.to_string())),
+            _ => Err(anyhow!("unable to parse an unknown engine: {}", s)),
         }
     }
 }
 
-/// Describe the ways this module can fail.
-#[derive(Debug, Error)]
-pub enum EngineError {
-    #[error("unknown engine: {0}")]
-    UnknownEngine(String),
-    #[error("the engine-ref must not be empty")]
-    EmptyEngineRef,
-    #[error(
-        "an engine-ref must not have more than 3 parts: [engine name]@[revision]@[repository]"
-    )]
-    TooLargeEngineRef,
-    #[error("the engine is specified by a path that is not buildable; use an engine-ref instead")]
-    CannotBuildEnginePath,
-    #[error("failed to build engine in Docker")]
-    FailedBuild(#[from] DockerError),
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn engine_filename() {
+        assert_eq!("libengine.so", get_engine_filename());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn engine_filename() {
+        assert_eq!("engine.dll", get_engine_filename());
+    }
+
+    #[test]
+    fn engine_ref() {
+        fn roundtrip(engine_ref: &str) -> Result<()> {
+            let er = EngineRef::from_str(engine_ref)?;
+            if engine_ref != er.to_string() {
+                Err(anyhow!("{} != {}", engine_ref, er.to_string()))
+            } else {
+                Ok(())
+            }
+        }
+
+        // Check valid engine-refs.
+        assert!(roundtrip("wasmtime").is_ok());
+        assert!(roundtrip("wasmtime@1234567").is_ok());
+        assert!(roundtrip("wasmtime@1234567@https://github.com/user/wasmtime").is_ok());
+
+        // Check invalid engine-refs.
+        assert!(roundtrip("other_engine").is_err());
+        assert!(roundtrip("wasmtime@1234567@https://github.com/user/wasmtime@...").is_err());
+    }
 }

--- a/crates/artifact/src/git.rs
+++ b/crates/artifact/src/git.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+/// Describe a specific Git commit in a repository; this is important for replicating the creation
+/// of artifacts. The fields are optional (for now), since in certain cases they can be assumed:
+/// the repository of some engines is well-known (e.g. Wasmtime) and the default branch can be used
+/// for the revision.
+///
+/// TODO eventually this and GitSource should merge together.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct GitLocation {
+    /// The URL of the Git repository.
+    pub repository: Option<String>,
+    /// A revision in the repository. According to [the Git
+    /// documentation](https://mirrors.edge.kernel.org/pub/software/scm/git/docs/gitrevisions.html#_specifying_revisions)
+    /// this could be, e.g.:
+    /// - a branch name
+    /// - a commit hash
+    /// - a tag
+    pub revision: Option<String>,
+}

--- a/crates/artifact/src/lib.rs
+++ b/crates/artifact/src/lib.rs
@@ -1,9 +1,13 @@
 mod artifact;
 mod docker;
+mod engine;
+mod git;
 mod metadata;
 mod wasm;
 
 pub use artifact::Artifact;
-pub use docker::Dockerfile;
+pub use docker::{DockerBuildArgs, Dockerfile};
+pub use engine::*;
+pub use git::GitLocation;
 pub use metadata::{BuildInfo, BuildSystem, GitSource};
 pub use wasm::WasmBenchmark;

--- a/crates/artifact/src/wasm.rs
+++ b/crates/artifact/src/wasm.rs
@@ -17,6 +17,11 @@ use wasmprinter;
 pub struct WasmBenchmark(PathBuf);
 
 impl WasmBenchmark {
+    /// Return the expected source location of a Wasm benchmark inside a benchmark Docker image.
+    pub fn source() -> PathBuf {
+        PathBuf::from("/benchmark.wasm")
+    }
+
     pub fn from<P: AsRef<Path>>(path: P) -> Self {
         Self(path.as_ref().canonicalize().expect("a valid path"))
     }

--- a/crates/artifact/tests/main.rs
+++ b/crates/artifact/tests/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use log::info;
 use pretty_env_logger;
-use sightglass_artifact::{Artifact, Dockerfile};
+use sightglass_artifact::{Artifact, Dockerfile, WasmBenchmark};
 use std::env;
 use std::path::PathBuf;
 
@@ -13,8 +13,9 @@ fn e2e() -> Result<()> {
 
     // Build a Wasm benchmark using its Dockerfile.
     let dockerfile = Dockerfile::from(PathBuf::from("./tests/Dockerfile"));
-    let benchmark_wasm = env::temp_dir().join("benchmark.wasm");
-    let wasmfile = dockerfile.build(benchmark_wasm)?;
+    let destination_wasm = env::temp_dir().join("benchmark.wasm");
+    dockerfile.extract(WasmBenchmark::source(), &destination_wasm, None)?;
+    let wasmfile = WasmBenchmark::from(destination_wasm);
 
     // Verify that the benchmark is a valid one.
     assert!(wasmfile.is_valid().is_ok());

--- a/crates/cli/src/build_engine.rs
+++ b/crates/cli/src/build_engine.rs
@@ -1,0 +1,29 @@
+use anyhow::Result;
+use sightglass_artifact::EngineBuilder;
+use structopt::StructOpt;
+
+/// Build a Wasm benchmark from either an engine-ref or a Dockerfile and print the path the
+/// generated library.
+#[derive(Debug, StructOpt)]
+#[structopt(name = "build-engine")]
+pub struct BuildEngineCommand {
+    /// Force this tool to rebuild the benchmark, if possible.
+    #[structopt(long, short)]
+    force_rebuild: bool,
+
+    /// Either a well-known engine (e.g. `wasmtime` or `wasmtime@92350bf2` or
+    /// `wasmtime@92350bf2@https://github.com/user/wasmtime`) or a path to a Dockerfile.
+    #[structopt(index = 1, required = true, value_name = "ENGINE-REF OR DOCKERFILE")]
+    location: EngineBuilder,
+}
+
+impl BuildEngineCommand {
+    pub fn execute(&self) -> Result<()> {
+        let engine = self.location.as_engine();
+        if !engine.exists() || self.force_rebuild {
+            self.location.build()?;
+        }
+        println!("{}", engine.path().display());
+        Ok(())
+    }
+}

--- a/crates/cli/src/build_engine.rs
+++ b/crates/cli/src/build_engine.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use sightglass_artifact::EngineBuilder;
+use sightglass_artifact::{build_engine, get_known_engine_path};
 use structopt::StructOpt;
 
 /// Build a Wasm benchmark from either an engine-ref or a Dockerfile and print the path the
@@ -14,16 +14,16 @@ pub struct BuildEngineCommand {
     /// Either a well-known engine (e.g. `wasmtime` or `wasmtime@92350bf2` or
     /// `wasmtime@92350bf2@https://github.com/user/wasmtime`) or a path to a Dockerfile.
     #[structopt(index = 1, required = true, value_name = "ENGINE-REF OR DOCKERFILE")]
-    location: EngineBuilder,
+    location: String,
 }
 
 impl BuildEngineCommand {
     pub fn execute(&self) -> Result<()> {
-        let engine = self.location.as_engine();
-        if !engine.exists() || self.force_rebuild {
-            self.location.build()?;
+        let engine_path = get_known_engine_path(&self.location)?;
+        if !engine_path.exists() || self.force_rebuild {
+            build_engine(&self.location, &engine_path)?;
         }
-        println!("{}", engine.path().display());
+        println!("{}", engine_path.display());
         Ok(())
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,10 +1,12 @@
 mod benchmark;
-mod build;
+mod build_benchmark;
+mod build_engine;
 mod validate;
 
 use anyhow::Result;
 use benchmark::{BenchmarkCommand, InProcessBenchmarkCommand};
-use build::BuildCommand;
+use build_benchmark::BuildBenchmarkCommand;
+use build_engine::BuildEngineCommand;
 use log::trace;
 use structopt::{clap::AppSettings, StructOpt};
 use validate::ValidateCommand;
@@ -27,7 +29,8 @@ fn main() -> Result<()> {
     ],
 )]
 enum SightglassCommand {
-    Build(BuildCommand),
+    BuildBenchmark(BuildBenchmarkCommand),
+    BuildEngine(BuildEngineCommand),
     Benchmark(BenchmarkCommand),
     InProcessBenchmark(InProcessBenchmarkCommand),
     Validate(ValidateCommand),
@@ -37,7 +40,8 @@ impl SightglassCommand {
     fn execute(&self) -> Result<()> {
         trace!("Executing command: {:?}", &self);
         match self {
-            SightglassCommand::Build(build) => build.execute(),
+            SightglassCommand::BuildBenchmark(build) => build.execute(),
+            SightglassCommand::BuildEngine(build) => build.execute(),
             SightglassCommand::Benchmark(benchmark) => benchmark.execute(),
             SightglassCommand::InProcessBenchmark(benchmark) => benchmark.execute(),
             SightglassCommand::Validate(validate) => validate.execute(),

--- a/engines/wasmtime/Dockerfile
+++ b/engines/wasmtime/Dockerfile
@@ -7,4 +7,4 @@ RUN git clone ${REPOSITORY}
 WORKDIR /usr/src/wasmtime
 RUN git checkout ${REVISION} && git submodule update --init
 RUN cargo build -p wasmtime-bench-api --release
-RUN mv target/release/libwasmtime_bench_api.so /engine.so
+RUN mv target/release/libwasmtime_bench_api.so /libengine.so

--- a/engines/wasmtime/Dockerfile
+++ b/engines/wasmtime/Dockerfile
@@ -1,0 +1,10 @@
+FROM rust:1.48
+ARG REPOSITORY=https://github.com/bytecodealliance/wasmtime/
+ARG REVISION=main
+
+WORKDIR /usr/src
+RUN git clone ${REPOSITORY}
+WORKDIR /usr/src/wasmtime
+RUN git checkout ${REVISION} && git submodule update --init
+RUN cargo build -p wasmtime-bench-api --release
+RUN mv target/release/libwasmtime_bench_api.so /engine.so


### PR DESCRIPTION
Eventually this check should run only a smoke test version of the benchmarks to avoid over-long CI times, but the intent remains the same: we want to ensure that the tooling and benchmarks are always runnable.