### PR TITLE
Allow symlink usage when building benchmarks in Docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ checksum = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 dependencies = [
  "libc",
  "termion",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "rustc-demangle",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -205,9 +205,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "cc"
-version = "1.0.34"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f813bf45048a18eda9190fd3c6b78644146056740c43172a5a3699118588fd"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
@@ -231,7 +231,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -362,7 +362,7 @@ checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -382,7 +382,7 @@ checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -406,7 +406,7 @@ checksum = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -437,7 +437,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -584,7 +584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 dependencies = [
  "cc",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -594,7 +594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9367bdfa836b7e3cf895867f7a570283444da90562980ec2263d6e1569b16bc"
 dependencies = [
  "cfg-if 1.0.0",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -907,7 +907,7 @@ dependencies = [
  "libc",
  "rand_core 0.3.1",
  "rdrand",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -920,7 +920,7 @@ dependencies = [
  "fuchsia-cprng",
  "libc",
  "rand_core 0.3.1",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -939,7 +939,7 @@ dependencies = [
  "rand_os",
  "rand_pcg 0.1.2",
  "rand_xorshift",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1035,7 +1035,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1049,7 +1049,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1148,7 +1148,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1330,6 +1330,7 @@ dependencies = [
  "pretty_env_logger",
  "serde",
  "serde_json",
+ "tar",
  "thiserror",
  "wasmparser 0.67.0",
  "wasmprinter",
@@ -1433,6 +1434,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489997b7557e9a43e192c527face4feacc78bfbe6eed67fd55c4c9e381cba290"
+dependencies = [
+ "filetime",
+ "libc",
+ "redox_syscall",
+ "xattr",
+]
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,7 +1463,7 @@ checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
  "dirs 1.0.5",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1528,7 +1541,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1723,9 +1736,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -1749,7 +1762,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.7",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1757,3 +1770,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
+]

--- a/benchmarks-next/.gitignore
+++ b/benchmarks-next/.gitignore
@@ -1,1 +1,0 @@
-sightglass.h

--- a/benchmarks-next/Dockerfile.emscripten
+++ b/benchmarks-next/Dockerfile.emscripten
@@ -1,0 +1,7 @@
+FROM emscripten/emsdk:2.0.8
+
+WORKDIR /
+COPY benchmark.c .
+COPY sightglass.h .
+RUN emcc benchmark.c -O3 -g -DNDEBUG -I. -o benchmark.wasm
+# We output the Wasm file to /benchmark.wasm, where the client expects it.

--- a/benchmarks-next/blake3-simd/benchmark.c
+++ b/benchmarks-next/blake3-simd/benchmark.c
@@ -11,7 +11,7 @@ int main()
     blake3_hasher_init(&hasher);
 
     // Initialize the 64K buffer.
-    unsigned char buffer[BUFFER_SIZE] = {0};
+    unsigned char buffer[BUFFER_SIZE] = { 0 };
 
     // Define the hash output; BLAKE3_OUT_LEN is the default output length, 32 bytes.
     uint8_t output[BLAKE3_OUT_LEN];

--- a/benchmarks-next/blake3-simd/sightglass.h
+++ b/benchmarks-next/blake3-simd/sightglass.h
@@ -1,0 +1,1 @@
+../../include/sightglass-next.h

--- a/benchmarks-next/build.sh
+++ b/benchmarks-next/build.sh
@@ -9,10 +9,6 @@ for DOCKERFILE in $(find $PROJECT_DIR/benchmarks-next -name Dockerfile); do
     BENCH_DIR=$(dirname $DOCKERFILE)
     BENCH_NAME=$(basename $BENCH_DIR)
 
-    # Copy the sightglass header into the bench directory (TODO remove; this is a hack to avoid
-    # duplicating the header everywhere since Docker will not recognize linked context files).
-    cp $PROJECT_DIR/include/sightglass-next.h $BENCH_DIR/sightglass.h
-
     # Build the Wasm benchmark.
     $SIGHTGLASS build-benchmark $DOCKERFILE -d $BENCH_DIR/benchmark.wasm --emit-wat
 done

--- a/benchmarks-next/noop/Dockerfile
+++ b/benchmarks-next/noop/Dockerfile
@@ -1,7 +1,1 @@
-FROM emscripten/emsdk:2.0.8
-
-WORKDIR /
-COPY benchmark.c .
-COPY sightglass.h .
-RUN emcc benchmark.c -O3 -g -DNDEBUG -I. -o benchmark.wasm
-# We output the Wasm file to /benchmark.wasm, where the client expects it.
+../Dockerfile.emscripten

--- a/benchmarks-next/noop/sightglass.h
+++ b/benchmarks-next/noop/sightglass.h
@@ -1,0 +1,1 @@
+../../include/sightglass-next.h

--- a/benchmarks-next/shootout-ackermann/Dockerfile
+++ b/benchmarks-next/shootout-ackermann/Dockerfile
@@ -1,7 +1,1 @@
-FROM emscripten/emsdk:2.0.8
-
-WORKDIR /
-COPY benchmark.c .
-COPY sightglass.h .
-RUN emcc benchmark.c -O3 -g -DNDEBUG -I. -o benchmark.wasm
-# We output the Wasm file to /benchmark.wasm, where the client expects it.
+../Dockerfile.emscripten

--- a/benchmarks-next/shootout-ackermann/sightglass.h
+++ b/benchmarks-next/shootout-ackermann/sightglass.h
@@ -1,0 +1,1 @@
+../../include/sightglass-next.h

--- a/crates/artifact/Cargo.toml
+++ b/crates/artifact/Cargo.toml
@@ -11,6 +11,7 @@ blake3 = "0.3"
 dirs = "3.0"
 log = "0.4"
 serde = { version = "1.0.118", features = ["derive"] }
+tar = "0.4"
 thiserror = "1.0"
 wasmparser = "0.67"
 wasmprinter = "0.2"

--- a/crates/artifact/tests/Dockerfile
+++ b/crates/artifact/tests/Dockerfile
@@ -1,6 +1,7 @@
 FROM emscripten/emsdk:2.0.8
 
 WORKDIR /
+COPY sightglass.h .
 COPY benchmark.c .
 RUN emcc benchmark.c -O3 -g -DNDEBUG -s TOTAL_MEMORY=268435456 -o benchmark.wasm
 # We output the Wasm file to /benchmark.wasm, where the client expects it.

--- a/crates/artifact/tests/benchmark.c
+++ b/crates/artifact/tests/benchmark.c
@@ -1,20 +1,15 @@
 #include <stdio.h>
+#include "sightglass.h"
 
 __attribute__((export_name("add")))
-__attribute__((noinline))
-int add(int a, int b) {
+__attribute__((noinline)) int
+add(int a, int b)
+{
     return a + b;
 }
 
-__attribute__((import_module("bench")))
-__attribute__((import_name("start")))
-void bench_start();
-
-__attribute__((import_module("bench")))
-__attribute__((import_name("end")))
-void bench_end();
-
-int main() {
+int main()
+{
     bench_start();
     int c = add(40, 2);
     bench_end();

--- a/crates/artifact/tests/sightglass.h
+++ b/crates/artifact/tests/sightglass.h
@@ -1,0 +1,1 @@
+../../../include/sightglass-next.h


### PR DESCRIPTION
This involves creating a TAR archive with any symlinks materialized and passing this to Docker via `stdin`. I believe the deduplication this allows is a weighter advantage than the potential for [symlinks being used insecurely](https://github.com/moby/moby/issues/1676).