### PR TITLE
Add CI step to check that default rustfmt is used

### DIFF
--- a/.github/workflows/sightglass.yml
+++ b/.github/workflows/sightglass.yml
@@ -11,6 +11,19 @@ env:
   RUST_LOG: info
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+    - run: rustup component add rustfmt
+    - run: cargo fmt --all -- --check
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
If we really want to get serious about this we can add a similar check for all of the C code.