### PR TITLE
Fix: perf counters must be reset on Measure::start and disabled on Measure::end

### DIFF
--- a/crates/recorder/src/measure/counters.rs
+++ b/crates/recorder/src/measure/counters.rs
@@ -72,10 +72,12 @@ impl CounterMeasure {
 
 impl Measure for CounterMeasure {
     fn start(&mut self) {
+        self.event_group.reset().unwrap();
         self.event_group.enable().unwrap()
     }
 
     fn end(&mut self, phase: Phase, measurements: &mut Measurements) {
+        self.event_group.disable().unwrap();
         let counts = self.event_group.read().unwrap();
         measurements.reserve(4);
         measurements.add(phase, "cpu-cycles".into(), counts[&self.cpu_cycles]);


### PR DESCRIPTION
@fitzgen, the `disable` call was removed in the last set of commits; `reset` was not present but should be if we are going to reuse `Measure`s within a process.