### PR TITLE
Move Format to sightglass-data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,13 +1341,12 @@ name = "sightglass-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "csv",
  "libloading 0.6.6",
  "log 0.4.11",
  "pretty_env_logger",
  "rand 0.7.3",
- "serde_json",
  "sightglass-artifact",
+ "sightglass-data",
  "sightglass-recorder",
  "structopt",
  "thiserror",
@@ -1357,7 +1356,10 @@ dependencies = [
 name = "sightglass-data"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "csv",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -10,9 +10,8 @@ libloading = "0.6"
 log = "0.4"
 pretty_env_logger = "0.4"
 sightglass-artifact = { path = "../artifact" }
+sightglass-data = { path = "../data" }
 sightglass-recorder = { path = "../recorder" }
 structopt = { version = "0.3", features = ["color", "suggestions"] }
 thiserror = "1.0"
-serde_json = "1.0.60"
-csv = "1.1.5"
 rand = { version = "0.7.3", features = ["small_rng"] }

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-serde = { version = "1.0.118", features = ["derive"] }
+anyhow = ""
+csv = "1.1.5"
+serde = { version = "1.0.118", features = ["derive", "rc"] }
+serde_json = "1.0.60"

--- a/crates/data/src/format.rs
+++ b/crates/data/src/format.rs
@@ -1,0 +1,76 @@
+//! Describe the serialization formats used in sightglass data.
+use anyhow::Result;
+use core::fmt;
+use csv::ReaderBuilder;
+use serde::{de::DeserializeOwned, Serialize};
+use std::{
+    io::{Read, Write},
+    str::FromStr,
+};
+
+/// Describes the input/output formats for the data structures in the `sightglass-data` crate.
+#[derive(Clone, Copy, Debug)]
+pub enum Format {
+    /// The JSON format.
+    Json,
+    /// The CSV format.
+    Csv,
+}
+
+impl Format {
+    /// Read a list of `T` using the selected format.
+    pub fn read<'de, T, R>(&self, reader: R) -> Result<Vec<T>>
+    where
+        R: Read + Sized,
+        T: DeserializeOwned,
+    {
+        Ok(match self {
+            Format::Json => serde_json::from_reader(reader)?,
+            Format::Csv => {
+                let mut reader = ReaderBuilder::new().has_headers(false).from_reader(reader);
+                reader.deserialize().map(|r| r.unwrap()).collect()
+            }
+        })
+    }
+
+    /// Write a list of `T` using the selected format.
+    pub fn write<T, W>(&self, objects: &[T], writer: W) -> Result<()>
+    where
+        T: Serialize,
+        W: Write + Sized,
+    {
+        Ok(match self {
+            Format::Json => serde_json::to_writer(writer, objects)?,
+            Format::Csv => {
+                let mut csv = csv::WriterBuilder::new()
+                    .has_headers(false)
+                    .from_writer(writer);
+                for o in objects {
+                    csv.serialize(o)?;
+                }
+                csv.flush()?;
+            }
+        })
+    }
+}
+
+impl fmt::Display for Format {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Format::Json => write!(f, "json"),
+            Format::Csv => write!(f, "csv"),
+        }
+    }
+}
+
+impl FromStr for Format {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, &'static str> {
+        match s {
+            "json" => Ok(Format::Json),
+            "csv" => Ok(Format::Csv),
+            _ => Err("output format must be either 'json' or 'csv'"),
+        }
+    }
+}

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![deny(missing_docs, missing_debug_implementations)]
 
+mod format;
+pub use format::Format;
+
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 

--- a/crates/data/tests/deserialize.rs
+++ b/crates/data/tests/deserialize.rs
@@ -1,0 +1,16 @@
+use sightglass_data::{Format, Measurement};
+use std::fs::File;
+
+#[test]
+fn json() {
+    let file = File::open("tests/results.json").unwrap();
+    let measurements: Vec<Measurement> = Format::Json.read(file).unwrap();
+    assert_eq!(measurements.len(), 9);
+}
+
+#[test]
+fn csv() {
+    let file = File::open("tests/results.csv").unwrap();
+    let measurements: Vec<Measurement> = Format::Csv.read(file).unwrap();
+    assert_eq!(measurements.len(), 9);
+}

--- a/crates/data/tests/results.csv
+++ b/crates/data/tests/results.csv
@@ -1,0 +1,9 @@
+x86_64,wasmtime,benchmarks-next/noop/benchmark.wasm,1711158,0,Compilation,wall-cycles,7193709
+x86_64,wasmtime,benchmarks-next/noop/benchmark.wasm,1711158,0,Instantiation,wall-cycles,668820
+x86_64,wasmtime,benchmarks-next/noop/benchmark.wasm,1711158,0,Execution,wall-cycles,1075
+x86_64,wasmtime,benchmarks-next/noop/benchmark.wasm,1711158,1,Compilation,wall-cycles,6128596
+x86_64,wasmtime,benchmarks-next/noop/benchmark.wasm,1711158,1,Instantiation,wall-cycles,481781
+x86_64,wasmtime,benchmarks-next/noop/benchmark.wasm,1711158,1,Execution,wall-cycles,813
+x86_64,wasmtime,benchmarks-next/noop/benchmark.wasm,1711158,2,Compilation,wall-cycles,5888744
+x86_64,wasmtime,benchmarks-next/noop/benchmark.wasm,1711158,2,Instantiation,wall-cycles,449150
+x86_64,wasmtime,benchmarks-next/noop/benchmark.wasm,1711158,2,Execution,wall-cycles,740

--- a/crates/data/tests/results.json
+++ b/crates/data/tests/results.json
@@ -1,0 +1,92 @@
+[
+    {
+        "arch": "x86_64",
+        "engine": "wasmtime",
+        "wasm": "benchmarks-next/noop/benchmark.wasm",
+        "process": 1701529,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "wall-cycles",
+        "count": 37063003
+    },
+    {
+        "arch": "x86_64",
+        "engine": "wasmtime",
+        "wasm": "benchmarks-next/noop/benchmark.wasm",
+        "process": 1701529,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "wall-cycles",
+        "count": 3386636
+    },
+    {
+        "arch": "x86_64",
+        "engine": "wasmtime",
+        "wasm": "benchmarks-next/noop/benchmark.wasm",
+        "process": 1701529,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "wall-cycles",
+        "count": 4725
+    },
+    {
+        "arch": "x86_64",
+        "engine": "wasmtime",
+        "wasm": "benchmarks-next/noop/benchmark.wasm",
+        "process": 1701529,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "wall-cycles",
+        "count": 34267724
+    },
+    {
+        "arch": "x86_64",
+        "engine": "wasmtime",
+        "wasm": "benchmarks-next/noop/benchmark.wasm",
+        "process": 1701529,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "wall-cycles",
+        "count": 2541521
+    },
+    {
+        "arch": "x86_64",
+        "engine": "wasmtime",
+        "wasm": "benchmarks-next/noop/benchmark.wasm",
+        "process": 1701529,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "wall-cycles",
+        "count": 4661
+    },
+    {
+        "arch": "x86_64",
+        "engine": "wasmtime",
+        "wasm": "benchmarks-next/noop/benchmark.wasm",
+        "process": 1701529,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "wall-cycles",
+        "count": 36150712
+    },
+    {
+        "arch": "x86_64",
+        "engine": "wasmtime",
+        "wasm": "benchmarks-next/noop/benchmark.wasm",
+        "process": 1701529,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "wall-cycles",
+        "count": 2552025
+    },
+    {
+        "arch": "x86_64",
+        "engine": "wasmtime",
+        "wasm": "benchmarks-next/noop/benchmark.wasm",
+        "process": 1701529,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "wall-cycles",
+        "count": 4983
+    }
+]


### PR DESCRIPTION
Adds `read` and `write` helper methods for converting lists of objects (which will be used by new, upcoming summary objects) and adds tests.