### PR TITLE
Add initial 'sightglass-cli analyze' command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,6 +1320,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "sightglass-analysis"
+version = "0.1.0"
+dependencies = [
+ "sightglass-data",
+]
+
+[[package]]
 name = "sightglass-artifact"
 version = "0.1.0"
 dependencies = [
@@ -1345,6 +1352,7 @@ dependencies = [
  "log 0.4.11",
  "pretty_env_logger",
  "rand 0.7.3",
+ "sightglass-analysis",
  "sightglass-artifact",
  "sightglass-data",
  "sightglass-recorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ hwloc = "0.5"
 
 [workspace]
 members = [
+    "crates/analysis",
     "crates/artifact",
     "crates/cli",
     "crates/data",

--- a/crates/analysis/Cargo.toml
+++ b/crates/analysis/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "sightglass-analysis"
+version = "0.1.0"
+authors = ["Andrew Brown <andrew.brown@intel.com>"]
+edition = "2018"
+
+[dependencies]
+sightglass-data = { path = "../data" }

--- a/crates/analysis/src/lib.rs
+++ b/crates/analysis/src/lib.rs
@@ -1,0 +1,167 @@
+use sightglass_data::{Measurement, Phase, Summary};
+use std::{borrow::Cow, collections::BTreeSet};
+
+/// Summarize measurements grouped by: architecture, engine, benchmark file, phase and event.
+pub fn summarize<'a>(measurements: &[Measurement<'a>]) -> Vec<Summary<'a>> {
+    let mut summaries = Vec::new();
+    for k in keys(&measurements) {
+        let grouped_counts: Vec<_> = measurements
+            .iter()
+            .filter(|m| k.matches(m))
+            .map(|m| m.count)
+            .collect();
+        summaries.push(Summary {
+            arch: k.arch,
+            engine: k.engine,
+            wasm: k.wasm,
+            phase: k.phase,
+            event: k.event,
+            min: grouped_counts
+                .iter()
+                .cloned()
+                .min()
+                .expect("at least one element"),
+            max: grouped_counts
+                .iter()
+                .cloned()
+                .max()
+                .expect("at least one element"),
+            mean: mean(&grouped_counts),
+            mean_deviation: mean_deviation(&grouped_counts),
+        })
+    }
+    summaries
+}
+
+/// Extract the keys (i.e. `phase` and `event`) for the groups of measurements to aggregate.
+fn keys<'a>(measurements: &[Measurement<'a>]) -> Vec<Key<'a>> {
+    let set: BTreeSet<_> = measurements
+        .iter()
+        .cloned()
+        .map(|m| Key {
+            arch: m.arch,
+            engine: m.engine,
+            wasm: m.wasm,
+            phase: m.phase,
+            event: m.event,
+        })
+        .collect();
+    set.into_iter().collect()
+}
+#[derive(PartialOrd, Ord, PartialEq, Eq, Hash)]
+struct Key<'a> {
+    arch: Cow<'a, str>,
+    engine: Cow<'a, str>,
+    wasm: Cow<'a, str>,
+    phase: Phase,
+    event: Cow<'a, str>,
+}
+impl Key<'_> {
+    fn matches(&self, m: &Measurement) -> bool {
+        self.arch == m.arch
+            && self.engine == m.engine
+            && self.wasm == m.wasm
+            && self.phase == m.phase
+            && self.event == m.event
+    }
+}
+
+/// Calculate the arithmetic mean of a slice of numbers.
+fn mean(numbers: &[u64]) -> f64 {
+    numbers.iter().sum::<u64>() as f64 / numbers.len() as f64
+}
+
+/// Calculate the mean deviation (note: not standard deviation) of a slice of numbers.
+fn mean_deviation(numbers: &[u64]) -> f64 {
+    let mean = mean(numbers);
+    numbers
+        .iter()
+        .map(|&c| (mean - c as f64).abs())
+        .sum::<f64>()
+        / numbers.len() as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sightglass_data::Phase;
+
+    #[test]
+    fn simple_statistics() {
+        fn measurement<'a>(count: u64) -> Measurement<'a> {
+            Measurement {
+                arch: "x86".into(),
+                engine: "wasmtime".into(),
+                wasm: "bench.wasm".into(),
+                process: 42,
+                iteration: 0,
+                phase: Phase::Compilation,
+                event: "wall-cycles".into(),
+                count,
+            }
+        }
+        let measurements = vec![measurement(0), measurement(1), measurement(2)];
+
+        assert_eq!(
+            summarize(&measurements),
+            vec![Summary {
+                arch: "x86".into(),
+                engine: "wasmtime".into(),
+                wasm: "bench.wasm".into(),
+                phase: Phase::Compilation,
+                event: "wall-cycles".into(),
+                mean: 1.0,
+                min: 0,
+                max: 2,
+                mean_deviation: 2f64 / 3f64
+            }]
+        );
+    }
+
+    #[test]
+    fn interleaving_phases() {
+        fn measurement<'a>(phase: Phase, count: u64) -> Measurement<'a> {
+            Measurement {
+                arch: "x86".into(),
+                engine: "wasmtime".into(),
+                wasm: "bench.wasm".into(),
+                process: 42,
+                iteration: 0,
+                phase,
+                event: "wall-cycles".into(),
+                count,
+            }
+        }
+        let measurements = vec![
+            measurement(Phase::Compilation, 0),
+            measurement(Phase::Execution, 1),
+            measurement(Phase::Compilation, 2),
+        ];
+
+        assert_eq!(summarize(&measurements).len(), 2);
+    }
+
+    #[test]
+    fn matching_fields() {
+        let key = Key {
+            arch: "x86".into(),
+            engine: "wasmtime".into(),
+            wasm: "bench.wasm".into(),
+            phase: Phase::Compilation,
+            event: "wall-cycles".into(),
+        };
+
+        // More test cases are needed, but this provides a sanity check for the matched key and
+        // measurement fields.
+        assert!(key.matches(&Measurement {
+            arch: "x86".into(),
+            engine: "wasmtime".into(),
+            wasm: "bench.wasm".into(),
+            process: 42,
+            iteration: 0,
+            phase: Phase::Compilation,
+            event: "wall-cycles".into(),
+            count: 42,
+        }));
+    }
+}

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -10,6 +10,7 @@ libloading = "0.6"
 log = "0.4"
 pretty_env_logger = "0.4"
 sightglass-artifact = { path = "../artifact" }
+sightglass-analysis = { path = "../analysis" }
 sightglass-data = { path = "../data" }
 sightglass-recorder = { path = "../recorder" }
 structopt = { version = "0.3", features = ["color", "suggestions"] }

--- a/crates/cli/src/analyze.rs
+++ b/crates/cli/src/analyze.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+use sightglass_analysis::summarize;
+use sightglass_data::{Format, Measurement};
+use std::io;
+use structopt::StructOpt;
+
+/// Analyze benchmark output; accepts raw benchmark results in `stdin` (i.e., from `sightglass-cli
+/// benchmark ...`) and prints the summarized results to `stdout`.
+#[derive(Debug, StructOpt)]
+#[structopt(name = "analyze")]
+pub struct AnalyzeCommand {
+    /// The format of the input data. Either 'json' or 'csv'.
+    #[structopt(short = "i", long = "input-format", default_value = "json")]
+    input_format: Format,
+
+    /// The format of the output data. Either 'json' or 'csv'.
+    #[structopt(short = "o", long = "output-format", default_value = "json")]
+    output_format: Format,
+}
+
+impl AnalyzeCommand {
+    pub fn execute(&self) -> Result<()> {
+        let measurements: Vec<Measurement> = self.input_format.read(io::stdin())?;
+        let summaries = summarize(&measurements);
+        self.output_format.write(&summaries, io::stdout())
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,8 +1,10 @@
+mod analyze;
 mod benchmark;
 mod build_benchmark;
 mod build_engine;
 mod validate;
 
+use analyze::AnalyzeCommand;
 use anyhow::Result;
 use benchmark::{BenchmarkCommand, InProcessBenchmarkCommand};
 use build_benchmark::BuildBenchmarkCommand;
@@ -34,6 +36,7 @@ enum SightglassCommand {
     Benchmark(BenchmarkCommand),
     InProcessBenchmark(InProcessBenchmarkCommand),
     Validate(ValidateCommand),
+    Analyze(AnalyzeCommand),
 }
 
 impl SightglassCommand {
@@ -45,6 +48,7 @@ impl SightglassCommand {
             SightglassCommand::Benchmark(benchmark) => benchmark.execute(),
             SightglassCommand::InProcessBenchmark(benchmark) => benchmark.execute(),
             SightglassCommand::Validate(validate) => validate.execute(),
+            SightglassCommand::Analyze(analyze) => analyze.execute(),
         }
     }
 }

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -55,7 +55,7 @@ pub struct Measurement<'a> {
 }
 
 /// A phase in a Wasm program's lifecycle.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub enum Phase {
     /// The compilation phase, where Wasm bytes are translated into native
     /// machine code.
@@ -66,4 +66,39 @@ pub enum Phase {
     /// The execution phase, where functions are called and instructions are
     /// executed.
     Execution,
+}
+
+/// A summary of grouped measurements.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Summary<'a> {
+    /// The CPU architecture on which this measurement was taken, for example
+    /// "aarch64" or "x86_64".
+    pub arch: Cow<'a, str>,
+
+    /// The file path of the wasmtime benchmark API shared library used to
+    /// record this measurement.
+    pub engine: Cow<'a, str>,
+
+    /// The file path of the Wasm benchmark program.
+    pub wasm: Cow<'a, str>,
+
+    /// The phase in a Wasm program's lifecycle that was measured: compilation,
+    /// instantiation, or execution.
+    pub phase: Phase,
+
+    /// The event that was measured: micro seconds of wall time, CPU cycles
+    /// executed, instructions retired, cache misses, etc.
+    pub event: Cow<'a, str>,
+
+    /// The minimum value of the `count` field.
+    pub min: u64,
+
+    /// The maximum value of the `count` field.
+    pub max: u64,
+
+    /// The arithmetic mean of the `count` field.
+    pub mean: f64,
+
+    /// The mean deviation (note: not standard deviation) of the `count` field.
+    pub mean_deviation: f64,
 }


### PR DESCRIPTION
This adds functionality to create aggregated statistics from serialized measurements. In this early incarnation, it is an additional `sightglass-cli` command that parses STDIN and aggregates min, max, mean, and mean deviation after grouping the measurements by phase and event type.

> Note: this should be merged after #75 as it depends on those changes.