### PR TITLE
Add additional 'nanoseconds' field to 'wall-cycles' measure

### DIFF
--- a/crates/recorder/src/measure/wall_cycles.rs
+++ b/crates/recorder/src/measure/wall_cycles.rs
@@ -21,7 +21,8 @@ impl Measure for WallCycleMeasure {
 
     fn end(&mut self, phase: Phase, measurements: &mut Measurements) {
         let end = self.0.now();
-        let elapsed = (end - self.1.take().expect("an existing timestamp")).ticks();
-        measurements.add(phase, "wall-cycles".into(), elapsed);
+        let elapsed = end - self.1.take().expect("an existing timestamp");
+        measurements.add(phase, "cycles".into(), elapsed.ticks());
+        measurements.add(phase, "nanoseconds".into(), elapsed.as_ns(&self.0));
     }
 }


### PR DESCRIPTION
Having both `cycles` and `nanoseconds` (calculated using the processor speed measured by the `precision` crate) is quite useful.