### PR TITLE
Avoid re-downloading wasi-sdk when building benchmarks

### DIFF
--- a/benchmarks-next/Dockerfile.wasi-sdk
+++ b/benchmarks-next/Dockerfile.wasi-sdk
@@ -1,13 +1,16 @@
-FROM ubuntu:18.04
 
+# This two-phase Dockerfile allows us to avoid re-downloading APT packages and wasi-sdk with every
+# build. First, retrieve wasi-sdk:
+FROM ubuntu:18.04 AS builder
 WORKDIR /
-
 RUN apt update && apt install -y wget
-
 # Download and extract wasi-sdk.
 RUN wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz
 RUN tar xvf wasi-sdk-12.0-linux.tar.gz
 
+FROM ubuntu:18.04
+WORKDIR /
+COPY --from=builder /wasi-sdk-12.0 /wasi-sdk-12.0/
 # Set common env vars.
 ENV CC=/wasi-sdk-12.0/bin/clang
 ENV CXX=/wasi-sdk-12.0/bin/clang++
@@ -15,7 +18,7 @@ ENV LD=/wasi-sdk-12.0/bin/lld
 ENV CFLAGS=--sysroot=/wasi-sdk-12.0/share/wasi-sysroot
 ENV CXXFLAGS=--sysroot=/wasi-sdk-12.0/share/wasi-sysroot
 ENV PATH /wasi-sdk-12.0
-
+# Compile benchmark.c to benchmark.wasm
 COPY benchmark.c .
 COPY sightglass.h .
 RUN $CC $CFLAGS benchmark.c -O3 -g -DNDEBUG -I. -o benchmark.wasm


### PR DESCRIPTION
Fixes #101 by using [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build). Instead of requiring us to publish Docker images for this type of thing (and keep them up-to-date), this should retrieve wasi-sdk only the first time and use cached images for subsequent runs.