### PR TITLE
Allow specifying file outputs + enhance benchmarks-next/run.sh

### DIFF
--- a/crates/cli/src/analyze.rs
+++ b/crates/cli/src/analyze.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use sightglass_analysis::summarize;
 use sightglass_data::{Format, Measurement};
-use std::io;
+use std::{
+    fs::File,
+    io::{self, BufReader, Read},
+};
 use structopt::StructOpt;
 
 /// Analyze benchmark output; accepts raw benchmark results in `stdin` (i.e., from `sightglass-cli
@@ -13,6 +16,10 @@ pub struct AnalyzeCommand {
     #[structopt(short = "i", long = "input-format", default_value = "json")]
     input_format: Format,
 
+    /// Path to the file that will be read from, or none to indicate stdin (default).
+    #[structopt(short = "f")]
+    input_file: Option<String>,
+
     /// The format of the output data. Either 'json' or 'csv'.
     #[structopt(short = "o", long = "output-format", default_value = "json")]
     output_format: Format,
@@ -20,7 +27,12 @@ pub struct AnalyzeCommand {
 
 impl AnalyzeCommand {
     pub fn execute(&self) -> Result<()> {
-        let measurements: Vec<Measurement> = self.input_format.read(io::stdin())?;
+        let file: Box<dyn Read> = if let Some(file) = self.input_file.as_ref() {
+            Box::new(BufReader::new(File::open(file)?))
+        } else {
+            Box::new(io::stdin())
+        };
+        let measurements: Vec<Measurement> = self.input_format.read(file)?;
         let summaries = summarize(&measurements);
         self.output_format.write(&summaries, io::stdout())
     }

--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use sightglass_artifact::get_built_engine;
-use sightglass_data::Format;
+use sightglass_data::{Format, Phase};
 use sightglass_recorder::measure::Measurements;
 use sightglass_recorder::{
     benchmark::{benchmark, BenchApi},
@@ -90,6 +90,10 @@ pub struct BenchmarkCommand {
         parse(from_os_str)
     )]
     wasm_files: Vec<PathBuf>,
+
+    /// Stop measuring after the given phase (compilation/instantiation/execution).
+    #[structopt(long("stop-after"))]
+    stop_after_phase: Option<Phase>,
 }
 
 impl BenchmarkCommand {
@@ -143,6 +147,7 @@ impl BenchmarkCommand {
                         &mut bench_api,
                         &working_dir,
                         &bytes,
+                        self.stop_after_phase.clone(),
                         &mut measure,
                         &mut measurements,
                     )?;

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -96,6 +96,9 @@ pub struct Summary<'a> {
     /// The maximum value of the `count` field.
     pub max: u64,
 
+    /// The median value of the `count` field.
+    pub median: u64,
+
     /// The arithmetic mean of the `count` field.
     pub mean: f64,
 

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -10,7 +10,7 @@ mod format;
 pub use format::Format;
 
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
+use std::{borrow::Cow, str::FromStr};
 
 /// A single measurement, for example instructions retired when compiling a Wasm
 /// module.
@@ -66,6 +66,18 @@ pub enum Phase {
     /// The execution phase, where functions are called and instructions are
     /// executed.
     Execution,
+}
+
+impl FromStr for Phase {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "compilation" => Ok(Self::Compilation),
+            "instantiation" => Ok(Self::Instantiation),
+            "execution" => Ok(Self::Execution),
+            _ => Err("invalid phase".into()),
+        }
+    }
 }
 
 /// A summary of grouped measurements.

--- a/crates/recorder/src/benchmark.rs
+++ b/crates/recorder/src/benchmark.rs
@@ -135,6 +135,8 @@ pub fn benchmark(
     bench_api: &mut BenchApi,
     working_dir: &Path,
     wasm_bytes: &[u8],
+    // Optionally stop after the given phase, rather than running all phases.
+    stop_after_phase: Option<Phase>,
     measure: &mut impl Measure,
     measurements: &mut Measurements,
 ) -> Result<()> {
@@ -144,9 +146,17 @@ pub fn benchmark(
     let module = engine.compile(wasm_bytes, measure, measurements);
     info!("Compiled successfully");
 
+    if stop_after_phase == Some(Phase::Compilation) {
+        return Ok(());
+    }
+
     // Measure the module instantiation.
     let instance = module.instantiate(measure, measurements);
     info!("Instantiated successfully");
+
+    if stop_after_phase == Some(Phase::Instantiation) {
+        return Ok(());
+    }
 
     // Measure the module execution; note that, because bench_start and bench_end are passed in to the Wasm module
     // as imports, we must retain the measurement state here, in the host code--see `static_measure`.

--- a/engines/wasmtime/Dockerfile
+++ b/engines/wasmtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.48
+FROM rust:1.51
 ARG REPOSITORY=https://github.com/bytecodealliance/wasmtime/
 ARG REVISION=main
 


### PR DESCRIPTION
I was trying to use sightglass for the first time, to measure a difference in terms of compile time for a specific change I'm making. I've added enough code so one can output the results to specific file paths (instead of stdio). I've also tweaked the main script so it'll store the results to a file, then these results can be analyzed using raw `jq` queries. This is a bit hacky, but it helps immediately answering questions like "what's the compile time for each benchmark". See the updates to the documentation for examples and new use cases.