### PR TITLE
Get CLI building on macOS/Windows

### DIFF
--- a/.github/workflows/sightglass.yml
+++ b/.github/workflows/sightglass.yml
@@ -25,7 +25,10 @@ jobs:
     - run: cargo fmt --all -- --check
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Install nightly

--- a/benchmarks-next/README.md
+++ b/benchmarks-next/README.md
@@ -13,7 +13,7 @@ effectively duplicate workloads.
 Build an individual benchmark program via:
 
 ```
-$ cargo run -p sightglass-cli -- build path/to/benchmark/Dockerfile
+$ cargo run -p sightglass-cli -- build-benchmark path/to/benchmark/Dockerfile
 ```
 
 Build all benchmark programs by entering this directory

--- a/crates/recorder/Cargo.toml
+++ b/crates/recorder/Cargo.toml
@@ -9,12 +9,14 @@ edition = "2018"
 anyhow = "1.0"
 libloading = "0.6"
 log = "0.4"
-perf-event = "0.4"
 precision = "0.1"
 serde = { version = "1.0.118", features = ["derive"] }
 sightglass-artifact = { path = "../artifact" }
 sightglass-data = { path = "../data" }
 thiserror = "1.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+perf-event = "0.4"
 
 [dev-dependencies]
 pretty_env_logger = "0.4"

--- a/crates/recorder/src/measure/counters.rs
+++ b/crates/recorder/src/measure/counters.rs
@@ -18,7 +18,6 @@ pub struct CounterMeasure {
 }
 
 impl CounterMeasure {
-    #[cfg(target_os = "linux")]
     pub fn new() -> Self {
         let mut group = Group::new().expect(
             "Unable to create event group; try setting /proc/sys/kernel/perf_event_paranoid to 2 \
@@ -60,13 +59,6 @@ impl CounterMeasure {
                 ),
             event_group: group,
         }
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    pub fn new() -> Self {
-        // This Measure doesn't currently support performance counter use on non-linux
-        // targets but it could in the future.
-        unimplemented!("`perf_event_open` is only available on Linux systems");
     }
 }
 
@@ -142,7 +134,7 @@ impl std::ops::AddAssign<PerfCounters> for PerfCounters {
     }
 }
 
-#[cfg(all(test, target_os = "linux"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::env;

--- a/crates/recorder/src/measure/mod.rs
+++ b/crates/recorder/src/measure/mod.rs
@@ -77,6 +77,7 @@ pub trait Measure: 'static {
     fn end(&mut self, phase: Phase, measurements: &mut Measurements);
 }
 
+#[cfg(target_os = "linux")]
 pub mod counters;
 pub mod noop;
 pub mod wall_cycles;
@@ -95,6 +96,7 @@ pub enum MeasureType {
     /// Measure wall-clock time using, e.g., `RDTSC`.
     WallCycles,
     /// Measure a combination of HW counters using `perf_event_open`.
+    #[cfg(target_os = "linux")]
     PerfCounters,
 }
 
@@ -103,6 +105,7 @@ impl fmt::Display for MeasureType {
         match self {
             MeasureType::Noop => write!(f, "noop"),
             MeasureType::WallCycles => write!(f, "wall-cycles"),
+            #[cfg(target_os = "linux")]
             MeasureType::PerfCounters => write!(f, "perf-counters"),
         }
     }
@@ -114,6 +117,7 @@ impl FromStr for MeasureType {
         match s {
             "noop" => Ok(Self::Noop),
             "wall-cycles" => Ok(Self::WallCycles),
+            #[cfg(target_os = "linux")]
             "perf-counters" => Ok(Self::PerfCounters),
             _ => Err("unknown measure type"),
         }
@@ -128,6 +132,7 @@ impl MeasureType {
         match self {
             Self::Noop => Box::new(noop::NoopMeasure::new()),
             Self::WallCycles => Box::new(wall_cycles::WallCycleMeasure::new()),
+            #[cfg(target_os = "linux")]
             Self::PerfCounters => Box::new(counters::CounterMeasure::new()),
         }
     }


### PR DESCRIPTION
Exclude the `perf-event` crate on non-Linux systems since it seems like
it probably only builds on Linux