### PR TITLE
Fix multi process measurements

### DIFF
--- a/.github/workflows/sightglass.yml
+++ b/.github/workflows/sightglass.yml
@@ -10,6 +10,10 @@ env:
   CARGO_TERM_COLOR: always
   RUST_LOG: info
 
+  # The Wasmtime commit that we build the bench API from for testing. Bumping
+  # this will automatically cause us to update our CI cache on the next run.
+  WASMTIME_COMMIT: "a2e71dafac4d2e42ed6edbc77081d39a40f4c3ff"
+
 jobs:
   format:
     runs-on: ubuntu-latest
@@ -31,13 +35,46 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
+
     - name: Install nightly
       uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
-    - uses: docker-practice/actions-setup-docker@v1
-      if: matrix.os == 'macos-latest'
+
+    - name: Download Cached Wasmtime Bench API
+      uses: actions/cache@v2
+      id: wasmtime-cache
+      with:
+        path: wasmtime/target/release/*wasmtime_bench_api.*
+        key: wasmtime-${{ runner.os }}-${{ env.WASMTIME_COMMIT }}
+
+    - name: Clone Wasmtime
+      if: steps.wasmtime-cache.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: "bytecodealliance/wasmtime"
+        ref: ${{ env.WASMTIME_COMMIT }}
+        submodules: recursive
+        path: wasmtime
+
+    - name: Build Wasmtime Bench API
+      if: steps.wasmtime-cache.outputs.cache-hit != 'true'
+      run: cargo build --manifest-path wasmtime/crates/bench-api/Cargo.toml --release
+
+    - name: Configure Wasmtime Bench API (linux)
+      if: runner.os == 'Linux'
+      run: echo "SIGHTGLASS_TEST_ENGINE=$(pwd)/wasmtime/target/release/libwasmtime_bench_api.so" >> $GITHUB_ENV
+
+    - name: Configure Wasmtime Bench API (macos)
+      if: runner.os == 'macOS'
+      run: echo "SIGHTGLASS_TEST_ENGINE=$(pwd)/wasmtime/target/release/libwasmtime_bench_api.dylib" >> $GITHUB_ENV
+
+    - name: Configure Wasmtime Bench API (windows)
+      if: runner.os == 'Windows'
+      run: echo "SIGHTGLASS_TEST_ENGINE=$(pwd)\\wasmtime\\target\\release\\wasmtime_bench_api.dll" >> $env:GITHUB_ENV
+
     - name: Build all
       run: cargo +nightly build --verbose --all
+
     - name: Test all
       run: cargo +nightly test --verbose --all

--- a/.github/workflows/sightglass.yml
+++ b/.github/workflows/sightglass.yml
@@ -35,6 +35,8 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly
+    - uses: docker-practice/actions-setup-docker@v1
+      if: matrix.os == 'macos-latest'
     - name: Build all
       run: cargo +nightly build --verbose --all
     - name: Test all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97be891acc47ca214468e09425d02cef3af2c94d0d82081cd02061f996802f14"
 
 [[package]]
+name = "assert_cmd"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f57fec1ac7e4de72dcc69811795f1a7172ed06012f80a5d1ee651b62484f588"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
@@ -355,6 +369,12 @@ dependencies = [
  "byteorder",
  "gzip-header",
 ]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
@@ -397,13 +417,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
+ "log 0.4.11",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+dependencies = [
+ "atty",
+ "humantime 2.1.0",
  "log 0.4.11",
  "regex",
  "termcolor",
@@ -449,6 +488,15 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -527,6 +575,12 @@ checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hwloc"
@@ -689,6 +743,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,12 +887,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
+dependencies = [
+ "difference",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f553275e5721409451eb85e15fd9a860a6e5ab4496eb215987502b5f5391f2"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
+
+[[package]]
 name = "pretty_env_logger"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
- "env_logger",
+ "env_logger 0.7.1",
  "log 0.4.11",
 ]
 
@@ -1284,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1365,10 +1454,15 @@ name = "sightglass-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
+ "csv",
+ "env_logger 0.8.3",
  "libloading 0.6.6",
  "log 0.4.11",
+ "predicates",
  "pretty_env_logger",
  "rand 0.7.3",
+ "serde_json",
  "sightglass-analysis",
  "sightglass-artifact",
  "sightglass-data",
@@ -1626,6 +1720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
 name = "twoway"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1819,15 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ members = [
 default-members = [
     "crates/cli"
 ]
+
+[dev-dependencies]
+serde_json = "1.0.64"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1.0"
 libloading = "0.6"
 log = "0.4"
 pretty_env_logger = "0.4"
+serde_json = "1.0.64"
 sightglass-artifact = { path = "../artifact" }
 sightglass-analysis = { path = "../analysis" }
 sightglass-data = { path = "../data" }
@@ -16,3 +17,9 @@ sightglass-recorder = { path = "../recorder" }
 structopt = { version = "0.3", features = ["color", "suggestions"] }
 thiserror = "1.0"
 rand = { version = "0.7.3", features = ["small_rng"] }
+csv = "1.1.6"
+
+[dev-dependencies]
+assert_cmd = "1.0.4"
+env_logger = "0.8.3"
+predicates = "1.0.8"

--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -315,7 +315,7 @@ impl BenchmarkCommand {
                 Format::Json => {
                     measurements.extend(
                         serde_json::from_slice::<Vec<Measurement<'_>>>(&output.stdout)
-                            .context("failed to read benchmakr subprocess's results")?,
+                            .context("failed to read benchmark subprocess's results")?,
                     );
                 }
                 Format::Csv { .. } => {

--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -192,15 +192,18 @@ impl BenchmarkCommand {
 
         let stdout_expected = wasm_file_dir.join("stdout.expected");
         if stdout_expected.exists() {
-            let stdout_expected_data = std::fs::read(&stdout_expected)
+            let stdout_expected_data = std::fs::read_to_string(&stdout_expected)
                 .with_context(|| format!("failed to read `{}`", stdout_expected.display()))?;
-            let stdout_actual_data = std::fs::read(stdout)
+            let stdout_actual_data = std::fs::read_to_string(stdout)
                 .with_context(|| format!("failed to read `{}`", stdout.display()))?;
+            // Compare lines so that we ignore `\n` on *nix vs `\r\n` on Windows.
+            let stdout_expected_data = stdout_expected_data.lines().collect::<Vec<_>>();
+            let stdout_actual_data = stdout_actual_data.lines().collect::<Vec<_>>();
             anyhow::ensure!(
                 stdout_expected_data == stdout_actual_data,
                 "Actual `stdout` does not match the expected `stdout`!\n\
-                               * Actual `stdout` is located at `{}`\n\
-                               * Expected `stdout` is located at `{}`",
+                 * Actual `stdout` is located at `{}`\n\
+                 * Expected `stdout` is located at `{}`",
                 stdout.display(),
                 stdout_expected.display(),
             );
@@ -215,15 +218,18 @@ impl BenchmarkCommand {
 
         let stderr_expected = wasm_file_dir.join("stderr.expected");
         if stderr_expected.exists() {
-            let stderr_expected_data = std::fs::read(&stderr_expected)
+            let stderr_expected_data = std::fs::read_to_string(&stderr_expected)
                 .with_context(|| format!("failed to read `{}`", stderr_expected.display()))?;
-            let stderr_actual_data = std::fs::read(stderr)
+            let stderr_actual_data = std::fs::read_to_string(stderr)
                 .with_context(|| format!("failed to read `{}`", stderr.display()))?;
+            // Compare lines so that we ignore `\n` on *nix vs `\r\n` on Windows.
+            let stderr_expected_data = stderr_expected_data.lines().collect::<Vec<_>>();
+            let stderr_actual_data = stderr_actual_data.lines().collect::<Vec<_>>();
             anyhow::ensure!(
                 stderr_expected_data == stderr_actual_data,
                 "Actual `stderr` does not match the expected `stderr`!\n\
-                               * Actual `stderr` is located at `{}`\n\
-                               * Expected `stderr` is located at `{}`",
+                 * Actual `stderr` is located at `{}`\n\
+                 * Expected `stderr` is located at `{}`",
                 stderr.display(),
                 stderr_expected.display(),
             );

--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use sightglass_artifact::get_built_engine;
-use sightglass_data::{Format, Phase};
+use sightglass_data::{Format, Measurement, Phase};
 use sightglass_recorder::measure::Measurements;
 use sightglass_recorder::{bench_api::BenchApi, benchmark::benchmark, measure::MeasureType};
 use std::{
@@ -242,6 +242,12 @@ impl BenchmarkCommand {
     /// Execute the benchmark(s) by spawning multiple processes. Each of the spawned processes will
     /// run the `execute_in_current_process` function above.
     fn execute_in_multiple_processes(&self) -> Result<()> {
+        let mut output_file: Box<dyn Write> = if let Some(file) = self.output_file.as_ref() {
+            Box::new(BufWriter::new(fs::File::create(file)?))
+        } else {
+            Box::new(io::stdout())
+        };
+
         let this_exe =
             std::env::current_exe().context("failed to get the current executable's path")?;
 
@@ -266,6 +272,9 @@ impl BenchmarkCommand {
             }
         }
 
+        // Accumulated measurements from all of our subprocesses.
+        let mut measurements = vec![];
+
         while !choices.is_empty() {
             let index = rng.gen_range(0, choices.len());
             let (engine, wasm, procs_left) = &mut choices[index];
@@ -273,7 +282,7 @@ impl BenchmarkCommand {
             let mut command = Command::new(&this_exe);
             command
                 .stdin(Stdio::null())
-                .stdout(Stdio::inherit())
+                .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
                 .arg("benchmark")
                 .arg("--processes")
@@ -291,14 +300,33 @@ impl BenchmarkCommand {
                 command.env("WASM_BENCH_USE_SMALL_WORKLOAD", "1");
             }
 
-            let status = command
-                .status()
-                .context("failed to spawn benchmark process")?;
+            let output = command
+                .output()
+                .context("failed to run benchmark subprocess")?;
 
             anyhow::ensure!(
-                status.success(),
-                "benchmark process did not exit successfully"
+                output.status.success(),
+                "benchmark subprocess did not exit successfully"
             );
+
+            // Parse the subprocess's output and add its measurements to our
+            // accumulation.
+            match self.output_format {
+                Format::Json => {
+                    measurements.extend(
+                        serde_json::from_slice::<Vec<Measurement<'_>>>(&output.stdout)
+                            .context("failed to read benchmakr subprocess's results")?,
+                    );
+                }
+                Format::Csv { .. } => {
+                    let mut reader = csv::Reader::from_reader(&output.stdout[..]);
+                    for measurement in reader.deserialize() {
+                        let measurement =
+                            measurement.context("failed to deserialize CSV measurement record")?;
+                        measurements.push(measurement);
+                    }
+                }
+            };
 
             *procs_left -= 1;
             if *procs_left == 0 {
@@ -306,6 +334,7 @@ impl BenchmarkCommand {
             }
         }
 
+        self.output_format.write(&measurements, &mut output_file)?;
         Ok(())
     }
 

--- a/crates/cli/tests/tests.rs
+++ b/crates/cli/tests/tests.rs
@@ -1,0 +1,95 @@
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use sightglass_data::Measurement;
+use std::process::Command;
+
+/// Get a `Command` for this crate's `sightglass-cli` executable.
+fn sightglass_cli() -> Command {
+    drop(env_logger::try_init());
+
+    // Make sure we only ever build Wasmtime once, and don't have N threads
+    // build it in parallel and race to be the one to save it onto the file
+    // system.
+    static BUILD_WASMTIME: std::sync::Once = std::sync::Once::new();
+    BUILD_WASMTIME.call_once(|| {
+        Command::cargo_bin("sightglass-cli")
+            .unwrap()
+            .current_dir("../..") // Run in the root of the repo.
+            .arg("build-engine")
+            .arg("wasmtime")
+            .assert()
+            .success();
+    });
+
+    Command::cargo_bin("sightglass-cli").unwrap()
+}
+
+/// Get the benchmark path for the benchmark with the given name.
+fn benchmark(benchmark_name: &str) -> String {
+    format!("../../benchmarks-next/{}/benchmark.wasm", benchmark_name).into()
+}
+
+#[test]
+fn help() {
+    sightglass_cli().arg("help").assert().success();
+}
+
+#[test]
+fn benchmark_json() {
+    let assert = sightglass_cli()
+        .arg("benchmark")
+        .arg("--processes")
+        .arg("2")
+        .arg("--iterations-per-process")
+        .arg("2")
+        .arg("--output-format")
+        .arg("json")
+        .arg("--")
+        .arg(benchmark("noop"))
+        .assert();
+
+    let stdout = std::str::from_utf8(&assert.get_output().stdout).unwrap();
+    eprintln!("=== stdout ===\n{}\n===========", stdout);
+    assert!(serde_json::from_str::<serde_json::Value>(stdout).is_ok());
+
+    assert
+        .stdout(
+            predicate::str::contains(benchmark("noop"))
+                .and(predicate::str::contains("Compilation"))
+                .and(predicate::str::contains("Instantiation"))
+                .and(predicate::str::contains("Execution")),
+        )
+        .success();
+}
+
+#[test]
+fn benchmark_csv() {
+    let assert = sightglass_cli()
+        .arg("benchmark")
+        .arg("--processes")
+        .arg("2")
+        .arg("--iterations-per-process")
+        .arg("2")
+        .arg("--output-format")
+        .arg("csv")
+        .arg("--")
+        .arg(benchmark("noop"))
+        .assert();
+
+    let stdout = std::str::from_utf8(&assert.get_output().stdout).unwrap();
+    eprintln!("=== stdout ===\n{}\n===========", stdout);
+    let mut reader = csv::Reader::from_reader(stdout.as_bytes());
+    for measurement in reader.deserialize::<Measurement<'_>>() {
+        drop(measurement.unwrap());
+    }
+
+    assert
+        .stdout(
+            predicate::str::starts_with("arch,engine,wasm,process,iteration,phase,event,count\n")
+                .and(predicate::str::contains(benchmark("noop")))
+                .and(predicate::str::contains("Compilation"))
+                .and(predicate::str::contains("Instantiation"))
+                .and(predicate::str::contains("Execution")),
+        )
+        .success();
+}

--- a/crates/cli/tests/tests.rs
+++ b/crates/cli/tests/tests.rs
@@ -12,13 +12,14 @@ fn sightglass_cli() -> Command {
     // system.
     static BUILD_WASMTIME: std::sync::Once = std::sync::Once::new();
     BUILD_WASMTIME.call_once(|| {
-        Command::cargo_bin("sightglass-cli")
+        let status = Command::cargo_bin("sightglass-cli")
             .unwrap()
             .current_dir("../..") // Run in the root of the repo.
             .arg("build-engine")
             .arg("wasmtime")
-            .assert()
-            .success();
+            .status()
+            .expect("failed to run `sightglass-cli build-engine`");
+        assert!(status.success());
     });
 
     Command::cargo_bin("sightglass-cli").unwrap()


### PR DESCRIPTION
Previously we would emit N copies of the CSV headers for our N processes, and N
JSON blobs (rather than one combined JSON blob) for N processes. Now we parse
the output from the child process and accumulate all the results from all
processes, and finally dump this accumulation after all subprocesses are done.

This also adds smoke tests that check we can benchmark with multiple processes
and that the resulting CSV/JSON parses okay. These can serve as a starting point
for a richer test suite.

Fixes #125