### PR TITLE
Add the `sightglass clean` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -486,7 +486,7 @@ checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.52",
  "winapi 0.3.9",
 ]
 
@@ -530,6 +530,17 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -688,9 +699,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "mime"
@@ -1048,12 +1059,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
  "rand_pcg 0.2.1",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1077,6 +1100,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.2",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,7 +1130,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -1116,6 +1158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1196,12 +1247,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d32b3053e5ced86e4bc0411fec997389532bf56b000e66cb4884eeeb41413d69"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+dependencies = [
+ "bitflags 1.2.1",
+]
+
+[[package]]
 name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 dependencies = [
- "redox_syscall",
+ "redox_syscall 0.1.52",
 ]
 
 [[package]]
@@ -1210,21 +1270,20 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
- "redox_syscall",
+ "getrandom 0.1.15",
+ "redox_syscall 0.1.52",
  "rust-argon2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
@@ -1238,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -1462,12 +1521,14 @@ dependencies = [
  "predicates",
  "pretty_env_logger",
  "rand 0.7.3",
+ "regex",
  "serde_json",
  "sightglass-analysis",
  "sightglass-artifact",
  "sightglass-data",
  "sightglass-recorder",
  "structopt",
+ "tempfile",
  "thiserror",
 ]
 
@@ -1579,7 +1640,7 @@ checksum = "489997b7557e9a43e192c527face4feacc78bfbe6eed67fd55c4c9e381cba290"
 dependencies = [
  "filetime",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.52",
  "xattr",
 ]
 
@@ -1591,6 +1652,20 @@ checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
  "rand 0.4.6",
  "remove_dir_all",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "rand 0.8.3",
+ "redox_syscall 0.2.8",
+ "remove_dir_all",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1620,7 +1695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 dependencies = [
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.52",
  "redox_termios",
 ]
 
@@ -1651,15 +1726,6 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.54",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]

--- a/crates/artifact/src/engine.rs
+++ b/crates/artifact/src/engine.rs
@@ -1,6 +1,5 @@
 use crate::{DockerBuildArgs, Dockerfile, GitLocation};
 use anyhow::{anyhow, Result};
-use dirs;
 use log;
 use std::{env, fmt, fs, path::Path, path::PathBuf, str::FromStr};
 
@@ -29,11 +28,7 @@ pub fn get_built_engine(engine: &str) -> Result<PathBuf> {
 /// Calculate the path to an engine library: e.g. `<user's app data
 /// dir>/sightglass/wasmtime@ab1234ef/libengine.so`.
 pub fn get_known_engine_path(slug: &str) -> Result<PathBuf> {
-    let mut p = dirs::data_local_dir().ok_or(anyhow!(
-        "missing an application data folder for storing sightglass engines; e.g. \
-        /home/.../.local/share, C:\\Users\\...\\AppData\\Local"
-    ))?;
-    p.push("sightglass");
+    let mut p = super::sightglass_data_dir()?;
     p.push(slug);
     p.push(get_engine_filename());
     Ok(p)

--- a/crates/artifact/src/lib.rs
+++ b/crates/artifact/src/lib.rs
@@ -5,9 +5,45 @@ mod git;
 mod metadata;
 mod wasm;
 
+use anyhow::Context;
+use std::path::PathBuf;
+
 pub use artifact::Artifact;
 pub use docker::{DockerBuildArgs, Dockerfile};
 pub use engine::*;
 pub use git::GitLocation;
 pub use metadata::{BuildInfo, BuildSystem, GitSource};
 pub use wasm::WasmBenchmark;
+
+/// Get the local directory where sightglass stores cached data.
+pub fn sightglass_data_dir() -> anyhow::Result<PathBuf> {
+    let mut p = dirs::data_local_dir().ok_or_else(|| {
+        anyhow::anyhow!(
+            "missing an application data folder for storing sightglass engines; e.g. \
+             /home/.../.local/share, C:\\Users\\...\\AppData\\Local"
+        )
+    })?;
+    p.push("sightglass");
+    Ok(p)
+}
+
+/// Clean up and remove any cached data.
+pub fn clean() -> anyhow::Result<()> {
+    let sightglass_data_dir = sightglass_data_dir()?;
+    if !sightglass_data_dir.is_dir() {
+        return Ok(());
+    }
+
+    log::info!(
+        "Recursively removing sightglass cached data in {}",
+        sightglass_data_dir.display()
+    );
+    std::fs::remove_dir_all(&sightglass_data_dir).with_context(|| {
+        format!(
+            "failed to recursively remove {}",
+            sightglass_data_dir.display(),
+        )
+    })?;
+
+    Ok(())
+}

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,8 +18,10 @@ structopt = { version = "0.3", features = ["color", "suggestions"] }
 thiserror = "1.0"
 rand = { version = "0.7.3", features = ["small_rng"] }
 csv = "1.1.6"
+regex = "1.5.4"
 
 [dev-dependencies]
 assert_cmd = "1.0.4"
 env_logger = "0.8.3"
 predicates = "1.0.8"
+tempfile = "3.2.0"

--- a/crates/cli/src/clean.rs
+++ b/crates/cli/src/clean.rs
@@ -1,0 +1,46 @@
+use anyhow::{Context, Result};
+use regex::Regex;
+use structopt::StructOpt;
+
+/// Remove cached artifacts and log files.
+#[derive(StructOpt, Debug)]
+#[structopt(name = "validate")]
+pub struct CleanCommand {}
+
+impl CleanCommand {
+    pub fn execute(&self) -> Result<()> {
+        // Remove cached data, e.g. engines.
+        sightglass_artifact::clean()?;
+
+        // Remove log files.
+        let log_file_regex = Regex::new(r"^(stdout|stderr)\-\w+\-\d+-\d+.log$").unwrap();
+        for entry in std::env::current_dir()?.read_dir()? {
+            let entry = entry?;
+
+            // Only consider files, not dirs or symlinks.
+            if !entry.file_type()?.is_file() {
+                continue;
+            }
+
+            let path = entry.path();
+
+            // If it doesn't have a file name, it definitely isn't a log file.
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                None => continue,
+                Some(n) => n,
+            };
+
+            // If it doesn't match our log file regex, it isn't a log file.
+            if !log_file_regex.is_match(name) {
+                continue;
+            }
+
+            // Okay! It's one of our log files!
+            log::info!("Removing log file: {}", path.display());
+            std::fs::remove_file(&path)
+                .with_context(|| format!("failed to remove {}", path.display()))?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod benchmark;
 mod build_benchmark;
 mod build_engine;
+mod clean;
 mod effect_size;
 mod summarize;
 mod validate;
@@ -9,6 +10,7 @@ use anyhow::Result;
 use benchmark::BenchmarkCommand;
 use build_benchmark::BuildBenchmarkCommand;
 use build_engine::BuildEngineCommand;
+use clean::CleanCommand;
 use effect_size::EffectSizeCommand;
 use log::trace;
 use structopt::{clap::AppSettings, StructOpt};
@@ -39,6 +41,7 @@ enum SightglassCommand {
     Validate(ValidateCommand),
     Summarize(SummarizeCommand),
     EffectSize(EffectSizeCommand),
+    Clean(CleanCommand),
 }
 
 impl SightglassCommand {
@@ -51,6 +54,7 @@ impl SightglassCommand {
             SightglassCommand::Validate(validate) => validate.execute(),
             SightglassCommand::Summarize(summarize) => summarize.execute(),
             SightglassCommand::EffectSize(effect_size) => effect_size.execute(),
+            SightglassCommand::Clean(clean) => clean.execute(),
         }
     }
 }


### PR DESCRIPTION
Removes cached data, e.g. built Wasm engines, and log files.

Fixes #112