### PR TITLE
Use lazy-static to initialize Precision only once per process.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,7 @@ name = "sightglass-recorder"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "lazy_static",
  "libloading 0.6.6",
  "log 0.4.11",
  "perf-event",

--- a/crates/recorder/Cargo.toml
+++ b/crates/recorder/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1.0.118", features = ["derive"] }
 sightglass-artifact = { path = "../artifact" }
 sightglass-data = { path = "../data" }
 thiserror = "1.0"
+lazy_static = "1.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 perf-event = "0.4"

--- a/crates/recorder/src/measure/wall_cycles.rs
+++ b/crates/recorder/src/measure/wall_cycles.rs
@@ -2,27 +2,33 @@
 //! wrapper around the `precision` crate to adapt it to the [Measure] API.
 
 use super::{Measure, Measurements};
+use lazy_static::lazy_static;
 use precision::{Config, Precision, Timestamp};
 use sightglass_data::Phase;
 
-pub struct WallCycleMeasure(Precision, Option<Timestamp>);
+lazy_static! {
+    static ref PRECISION: Precision = Precision::new(Config::default()).unwrap();
+}
+
+pub struct WallCycleMeasure(Option<Timestamp>);
 
 impl WallCycleMeasure {
     pub fn new() -> Self {
-        let precision = Precision::new(Config::default()).unwrap();
-        Self(precision, None)
+        Self(None)
     }
 }
 
 impl Measure for WallCycleMeasure {
     fn start(&mut self) {
-        self.1 = Some(self.0.now());
+        let start = PRECISION.now();
+        self.0 = Some(start);
     }
 
     fn end(&mut self, phase: Phase, measurements: &mut Measurements) {
-        let end = self.0.now();
-        let elapsed = end - self.1.take().expect("an existing timestamp");
+        let precision = &*PRECISION; // deref the lazy-static just once.
+        let end = precision.now();
+        let elapsed = end - self.0.take().expect("an existing timestamp");
         measurements.add(phase, "cycles".into(), elapsed.ticks());
-        measurements.add(phase, "nanoseconds".into(), elapsed.as_ns(&self.0));
+        measurements.add(phase, "nanoseconds".into(), elapsed.as_ns(precision));
     }
 }


### PR DESCRIPTION
Fixes #134.