### PR TITLE
 Interleave benchmark iterations from different processes 

### DIFF
--- a/crates/data/src/format.rs
+++ b/crates/data/src/format.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 /// Describes the input/output formats for the data structures in the `sightglass-data` crate.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Format {
     /// The JSON format.
     Json,


### PR DESCRIPTION
This commit makes it so that, rather than spawning a process for a Wasm
benchmark and engine pair and running all iterations for that process
immediately, we now spawn a bunch of processes and then run one iteration from a
random one of them at a time. This interleaves benchmark iterations, not just
processes.

This means that we need to have communication back and forth between the parent
process and the child processes. Before, we had fork/join style subprocesses
where we just spawned a child and waited for it to finish before starting the
next subprocess and there was no communication between the parent and child
before the child was done executing. In order to interleave benchmark
iterations, we need to spawn many processes, have them wait on the parent, and
have the parent tell one subprocess at a time to run one iteration and then wait
again. The way that this is done is with a very simple `stdin` and
`stdout`-based protocol. All children are waiting to read a newline on their
`stdin` before they run an iteration. The parent chooses a child, writes a
newline and then waits for the child to finish by reading a newline from the
child's `stdout`. When the child finishes its iteration, it writes a newline to
its `stdout`. When all iterations are complete, then the child writes its
results as JSON to `stdout`.

Fixes #139

