### PR TITLE
Add SpiderMonkey benchmark.

### DIFF
--- a/benchmarks-next/spidermonkey/Dockerfile
+++ b/benchmarks-next/spidermonkey/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:20.04
+
+RUN apt-get update
+RUN apt-get -y install git python3 python3-pip python3-distutils curl sudo
+RUN curl https://sh.rustup.rs | bash -s - -y
+ENV PATH=/root/.cargo/bin:$PATH
+
+# Build SpiderMonkey itself.
+WORKDIR /usr/src
+RUN git clone https://github.com/tschneidereit/spidermonkey-wasi-embedding
+WORKDIR /usr/src/spidermonkey-wasi-embedding
+ENV DEBIAN_FRONTEND=noninteractive
+RUN ./build-engine.sh
+
+RUN apt-get -y install wget
+WORKDIR /opt
+RUN wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-14/wasi-sdk-14.0-linux.tar.gz
+RUN tar zxvf wasi-sdk-14.0-linux.tar.gz
+RUN ln -s wasi-sdk-14.0 wasi-sdk
+
+WORKDIR /usr/src
+RUN mkdir benchmark && cd benchmark/
+COPY runtime.cpp .
+COPY sightglass.h .
+COPY build.sh .
+RUN ./build.sh
+

--- a/benchmarks-next/spidermonkey/build.sh
+++ b/benchmarks-next/spidermonkey/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -x -e
+
+SM=/usr/src/spidermonkey-wasi-embedding
+
+/opt/wasi-sdk/bin/clang++ -O3 -std=c++17 -o /benchmark.wasm runtime.cpp -I$SM/release/include/ $SM/release/lib/*.o $SM/release/lib/*.a
+
+/opt/wasi-sdk/bin/strip /benchmark.wasm

--- a/benchmarks-next/spidermonkey/runtime.cpp
+++ b/benchmarks-next/spidermonkey/runtime.cpp
@@ -1,0 +1,144 @@
+// Largely borrowed barebones SpiderMonkey toplevel wrapper from:
+// https://github.com/fastly/js-compute-runtime/blob/main/c-dependencies/js-compute-runtime/js-compute-runtime.cpp
+
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+
+#include <wasi/libc-environ.h>
+
+#include "sightglass.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winvalid-offsetof"
+
+#include "jsapi.h"
+#include "jsfriendapi.h"
+
+#include "js/CompilationAndEvaluation.h"
+#include "js/ContextOptions.h"
+#include "js/ForOfIterator.h"
+#include "js/Initialization.h"
+#include "js/Object.h"
+#include "js/SourceText.h"
+
+#pragma clang diagnostic pop
+
+using JS::Value;
+
+using JS::RootedValue;
+using JS::RootedObject;
+using JS::RootedString;
+
+using JS::HandleValue;
+using JS::HandleObject;
+using JS::MutableHandleValue;
+
+using JS::PersistentRooted;
+using JS::PersistentRootedVector;
+
+/* The class of the global object. */
+static JSClass global_class = {
+    "global",
+    JSCLASS_GLOBAL_FLAGS,
+    &JS::DefaultGlobalClassOps
+};
+
+JSContext* CONTEXT = nullptr;
+
+JS::PersistentRootedObject GLOBAL;
+
+static JS::PersistentRootedObjectVector* FETCH_HANDLERS;
+
+bool init_js() {
+  JS_Init();
+
+  JSContext *cx = JS_NewContext(JS::DefaultHeapMaxBytes);
+  if (!cx)
+      return false;
+  if (!js::UseInternalJobQueues(cx) || !JS::InitSelfHostedCode(cx))
+      return false;
+
+  JS::ContextOptionsRef(cx)
+    .setPrivateClassFields(true)
+    .setPrivateClassMethods(true)
+    .setClassStaticBlocks(true)
+    .setErgnomicBrandChecks(true);
+
+  JS::RealmOptions options;
+  options.creationOptions()
+    .setStreamsEnabled(true)
+    .setReadableByteStreamsEnabled(true)
+    .setBYOBStreamReadersEnabled(true)
+    .setReadableStreamPipeToEnabled(true)
+    .setWritableStreamsEnabled(true)
+    .setIteratorHelpersEnabled(true)
+    .setWeakRefsEnabled(JS::WeakRefSpecifier::EnabledWithoutCleanupSome);
+
+  RootedObject global(cx, JS_NewGlobalObject(cx, &global_class, nullptr, JS::FireOnNewGlobalHook,
+                                             options));
+  if (!global)
+      return false;
+
+  JSAutoRealm ar(cx, global);
+  if (!JS::InitRealmStandardClasses(cx))
+    return false;
+
+
+  CONTEXT = cx;
+  GLOBAL.init(cx, global);
+
+  return true;
+}
+
+static const char* BENCH =
+  "function fib(n) {\n"
+  "  if (n < 2) {\n"
+  "    return 1;\n"
+  "  } else {\n"
+  "    return fib(n-1) + fib(n-2);\n"
+  "  }\n"
+  "}\n"
+  "\n"
+  "fib(33);\n";
+
+bool eval_bench(JSContext* cx, MutableHandleValue result) {
+  JS::CompileOptions opts(cx);
+  opts.setForceFullParse();
+  opts.setFileAndLine("<stdin>", 1);
+
+  JS::SourceText<mozilla::Utf8Unit> srcBuf;
+  if (!srcBuf.init(cx, BENCH, strlen(BENCH), JS::SourceOwnership::TakeOwnership)) {
+      return false;
+  }
+
+  JS::RootedScript script(cx);
+  script = JS::Compile(cx, opts, srcBuf);
+  if (!script) return false;
+
+  bench_start();
+
+  // Execute the top-level script.
+  if (!JS_ExecuteScript(cx, script, result))
+    return false;
+
+  bench_end();
+
+  return true;
+}
+
+int main(int argc, const char *argv[]) {
+  if (!init_js())
+    exit(1);
+
+  JSContext* cx = CONTEXT;
+  RootedObject global(cx, GLOBAL);
+  JSAutoRealm ar(cx, global);
+  FETCH_HANDLERS = new JS::PersistentRootedObjectVector(cx);
+
+  RootedValue result(cx);
+  if (!eval_bench(cx, &result)) {
+    fprintf(stderr, "Error evaluating JS\n");
+    exit(1);
+  }
+}

--- a/benchmarks-next/spidermonkey/sightglass.h
+++ b/benchmarks-next/spidermonkey/sightglass.h
@@ -1,0 +1,37 @@
+#ifndef sightglass_h
+#define sightglass_h 1
+
+/**
+ * Call this function to indicate that recording should start. This call should be placed
+ * immediately prior to the code to measure with sightglass-recorder. The attributes allow compilers
+ * to generate the correct Wasm imports.
+ */
+__attribute__((import_module("bench")))
+__attribute__((import_name("start")))
+void bench_start();
+
+/**
+ * Call this function to indicate that recording should end. This call should be placed immediately
+ * after the code to measure with sightglass-recorder. The attributes allow compilers to generate
+ * the correct Wasm imports.
+ */
+__attribute__((import_module("bench")))
+__attribute__((import_name("end")))
+void bench_end();
+
+/**
+ * Call this function to prevent certain compiler-related optimizations related to knowing the value
+ * of the passed variable.
+ */
+#ifndef black_box
+static void _black_box(void *x)
+{
+    (void)x;
+}
+static void (*volatile black_box)(void *x) = _black_box;
+#else
+void black_box(void *x);
+#endif
+#define BLACK_BOX(X) black_box((void *)&(X))
+
+#endif


### PR DESCRIPTION
This benchmark builds SpiderMonkey using its support for running on
`wasm32-wasi` platforms, and links it with a simple toplevel that feeds
it a recursive Fibonacci function and evaluates `fib(33)`.

On my system, this benchmark has the following timing measurements:

```
compilation
  benchmarks-next/spidermonkey/benchmark.wasm
    cycles
      [8740808933 9440410499.20 9781710940] ./wasmtime.so
    nanoseconds
      [3807417356 4112157473.80 4260824860] ./wasmtime.so
instantiation
  benchmarks-next/spidermonkey/benchmark.wasm
    cycles
      [271009 288346.40 303439] ./wasmtime.so
    nanoseconds
      [118049 125600.80 132175] ./wasmtime.so
execution
  benchmarks-next/spidermonkey/benchmark.wasm
    cycles
      [7055231738 7076764356.40 7114914898] ./wasmtime.so
    nanoseconds
      [3073195167 3082574580.80 3099192612] ./wasmtime.so
```

It is a good test of both compile-time (SpiderMonkey itself is a large
program and takes the engine a nontrivial amount of time to compile) and
runtime (the interpreter loop is CPU-bound and involves several large
functions that are stress-tests of generated-code quality).