### PR TITLE
engine: update Rust version used to build Wasmtime to 1.60

### DIFF
--- a/engines/wasmtime/Dockerfile
+++ b/engines/wasmtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.54
+FROM rust:1.60
 ARG REPOSITORY=https://github.com/bytecodealliance/wasmtime/
 ARG REVISION=main
 


### PR DESCRIPTION
This is probably necessary before #162