### PR TITLE
engine: speed up Wasmtime engine build

### DIFF
--- a/engines/wasmtime/Dockerfile
+++ b/engines/wasmtime/Dockerfile
@@ -1,10 +1,16 @@
 FROM rust:1.60
 ARG REPOSITORY=https://github.com/bytecodealliance/wasmtime/
 ARG REVISION=main
+ARG BUILD="cargo build -p wasmtime-bench-api"
+ARG FLAGS="--release"
 
 WORKDIR /usr/src
-RUN git clone ${REPOSITORY}
-WORKDIR /usr/src/wasmtime
-RUN git checkout ${REVISION} && git submodule update --init
-RUN cargo build -p wasmtime-bench-api --release
+# Clone a single commit (actually, a "revision"--tags and branches work as well).
+RUN git init
+RUN git remote add origin ${REPOSITORY}
+RUN git fetch --depth 1 origin ${REVISION}
+RUN git checkout FETCH_HEAD
+RUN git submodule update --init --depth 1
+# Build the engine library.
+RUN ${BUILD} ${FLAGS}
 RUN mv target/release/libwasmtime_bench_api.so /libengine.so


### PR DESCRIPTION
Previously, the `Dockerfile` building the Wasmtime engine retrieved the
entire repository along with the entire repositories of the various
submodules. Now, only latest commit is retrieved for all of these
repositories.