### PR TITLE
recorder: stub out a mechanism for passing execution flags to engines

### DIFF
--- a/crates/recorder/src/bench_api.rs
+++ b/crates/recorder/src/bench_api.rs
@@ -32,6 +32,9 @@ struct WasmBenchConfig {
     execution_timer: *mut u8,
     execution_start: extern "C" fn(*mut u8),
     execution_end: extern "C" fn(*mut u8),
+
+    execution_flags_ptr: *const u8,
+    execution_flags_len: usize,
 }
 
 /// An shared library that implements our in-process benchmarking API.
@@ -86,6 +89,7 @@ where
         stdin_path: Option<&Path>,
         measurements: &'a mut Measurements<'c>,
         measure: &'a mut M,
+        execution_flags: Option<&'a str>,
     ) -> Self {
         let working_dir = working_dir.display().to_string();
         let stdout_path = stdout_path.display().to_string();
@@ -113,6 +117,8 @@ where
             execution_timer: measurement_data as *mut u8,
             execution_start: Self::execution_start,
             execution_end: Self::execution_end,
+            execution_flags_ptr: execution_flags.as_ref().map_or(ptr::null(), |p| p.as_ptr()),
+            execution_flags_len: execution_flags.as_ref().map_or(0, |p| p.len()),
         };
 
         let mut engine = ptr::null_mut();

--- a/crates/recorder/src/benchmark.rs
+++ b/crates/recorder/src/benchmark.rs
@@ -31,6 +31,7 @@ pub fn benchmark<'a, 'b, 'c>(
         stdin_path,
         measurements,
         measure,
+        None,
     );
 
     // Measure the module compilation.


### PR DESCRIPTION
In https://github.com/bytecodealliance/wasmtime/pull/4096, I added a way
to configure an engine using Wasmtime's CLI flags. This change adds some
stub fields in Sightglass for this flag string but does not fully wire
it up. I have a solution for configuring the execution flags using
`BuildInfo` in #167 so I will fully wire this up there; in the meantime,
Sightglass should still work as before with this stub implementation.