### PR TITLE
Allow `summarize` and `effect-size` to produce human-readable output

### DIFF
--- a/crates/analysis/src/lib.rs
+++ b/crates/analysis/src/lib.rs
@@ -1,9 +1,3 @@
-mod effect_size;
-mod keys;
-mod summarize;
-
-pub use {
-    effect_size::effect_size,
-    keys::{Key, KeyBuilder},
-    summarize::summarize,
-};
+pub mod effect_size;
+pub mod keys;
+pub mod summarize;

--- a/crates/cli/src/summarize.rs
+++ b/crates/cli/src/summarize.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use sightglass_analysis::summarize;
-use sightglass_data::{Format, Measurement};
+use sightglass_data::Format;
 use std::{
     fs::File,
-    io::{self, BufReader, Read},
+    io::{self, BufReader},
 };
 use structopt::StructOpt;
 
@@ -13,28 +13,38 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "summarize")]
 pub struct SummarizeCommand {
+    /// Path to the file(s) that will be read from, or none to indicate stdin (default).
+    #[structopt(short = "f")]
+    input_file: Option<Vec<String>>,
+
     /// The format of the input data. Either 'json' or 'csv'.
     #[structopt(short = "i", long = "input-format", default_value = "json")]
     input_format: Format,
 
-    /// Path to the file that will be read from, or none to indicate stdin (default).
-    #[structopt(short = "f")]
-    input_file: Option<String>,
-
-    /// The format of the output data. Either 'json' or 'csv'.
-    #[structopt(short = "o", long = "output-format", default_value = "json")]
-    output_format: Format,
+    /// The format of the output data. Either 'json' or 'csv'; if unspecified, print the output in
+    /// human-readable form.
+    #[structopt(short = "o", long = "output-format")]
+    output_format: Option<Format>,
 }
 
 impl SummarizeCommand {
     pub fn execute(&self) -> Result<()> {
-        let file: Box<dyn Read> = if let Some(file) = self.input_file.as_ref() {
-            Box::new(BufReader::new(File::open(file)?))
+        let measurements = if let Some(files) = self.input_file.as_ref() {
+            let mut ms = Vec::new();
+            for file in files {
+                let reader = BufReader::new(File::open(file)?);
+                ms.append(&mut self.input_format.read(reader)?);
+            }
+            ms
         } else {
-            Box::new(io::stdin())
+            self.input_format.read(io::stdin())?
         };
-        let measurements: Vec<Measurement> = self.input_format.read(file)?;
-        let summaries = summarize(&measurements);
-        self.output_format.write(&summaries, io::stdout())
+
+        let summaries = summarize::calculate(&measurements);
+        if let Some(output_format) = &self.output_format {
+            output_format.write(&summaries, io::stdout())
+        } else {
+            summarize::write(summaries, &mut io::stdout())
+        }
     }
 }


### PR DESCRIPTION
Previously, only the `benchmark` command understood how to print the
summarized results to a human-readable output. The `summarize` and
`effect-size` commands only could print to CSV or JSON. While
benchmarking a scenario that required separate runs and thus separate
result files, I realized that a) I had to reduce the various result
files to a single file and b) there was no way to print a human-readable
version of the summaries or effect sizes. This change refactors the
implementation of the human-readable display to the sightglass-analysis
crate so it can be used in multiple commands (`benchmark`, `summarize`,
`effect-size`). The human-readable output is used if the user does not
specify a (now optional) `--output-format`. This change also makes it
possible to pass multiple files to `summarize` and `effect-size`
commands