### PR TITLE
Wire through the engine configuration flags

### DIFF
--- a/crates/recorder/src/benchmark.rs
+++ b/crates/recorder/src/benchmark.rs
@@ -20,6 +20,7 @@ pub fn benchmark<'a, 'b, 'c>(
     stdin_path: Option<&Path>,
     wasm_bytes: &[u8],
     stop_after_phase: Option<Phase>,
+    execution_flags: Option<&str>,
     measure: &'a mut impl Measure,
     measurements: &'a mut Measurements<'c>,
 ) -> Result<()> {
@@ -36,7 +37,7 @@ pub fn benchmark<'a, 'b, 'c>(
         stdin_path,
         measurements,
         measure,
-        None,
+        execution_flags,
     );
 
     // Measure the module compilation.


### PR DESCRIPTION
In #169 we stubbed out a way to pass through configuration flags to an
engine. That PR corresponded with
https://github.com/bytecodealliance/wasmtime/pull/4096 in Wasmtime. This
change wires through the flags all the way through, e.g.:

```
sightglas-cli benchmark --engine ... --engine-flags '--vtune --opt-level 0'
```

Note that the bench-api structure field is named `execution_flags` but,
after some thought, exposing it here as `--engine-flags` makes more
sense.