### PR TITLE
Add a `fingerprint` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,16 @@ dependencies = [
  "cfg-if 0.1.10",
  "constant_time_eq",
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -222,6 +231,12 @@ name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+
+[[package]]
+name = "bytesize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
 
 [[package]]
 name = "cc"
@@ -281,6 +296,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "core_affinity"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,12 +314,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -362,6 +447,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -575,6 +670,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "httparse"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +835,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +851,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -800,6 +921,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "num"
@@ -868,6 +998,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+
+[[package]]
+name = "os_info"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eca3ecae1481e12c3d9379ec541b238a16f0b75c9a409942daa8ec20dbfdb62"
+dependencies = [
+ "log",
+ "serde",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1130,6 +1277,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1414,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "scroll"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1519,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "sightglass"
 version = "0.1.0"
 dependencies = [
@@ -1409,6 +1597,7 @@ dependencies = [
  "sightglass-analysis",
  "sightglass-build",
  "sightglass-data",
+ "sightglass-fingerprint",
  "sightglass-recorder",
  "structopt",
  "tempfile",
@@ -1423,6 +1612,22 @@ dependencies = [
  "csv",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "sightglass-fingerprint"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytesize",
+ "hostname",
+ "log",
+ "os_info",
+ "regex",
+ "serde",
+ "sha2",
+ "sightglass-build",
+ "sysinfo",
 ]
 
 [[package]]
@@ -1510,6 +1715,21 @@ dependencies = [
  "proc-macro2 1.0.37",
  "quote 1.0.18",
  "unicode-xid 0.2.2",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf915673a340ee41f2fc24ad1286c75ea92026f04b65a0d0e5132d80b95fc61"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "crates/build",
     "crates/cli",
     "crates/data",
+    "crates/fingerprint",
     "crates/recorder",
     "webui/sg-history"
 ]

--- a/crates/build/tests/main.rs
+++ b/crates/build/tests/main.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use log::info;
 use pretty_env_logger;
 use sightglass_build::{Dockerfile, WasmBenchmark};
 use std::env;

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1.0.64"
 sightglass-analysis = { path = "../analysis" }
 sightglass-build = { path = "../build" }
 sightglass-data = { path = "../data" }
+sightglass-fingerprint = { path = "../fingerprint" }
 sightglass-recorder = { path = "../recorder" }
 structopt = { version = "0.3", features = ["color", "suggestions"] }
 thiserror = "1.0"

--- a/crates/cli/src/fingerprint.rs
+++ b/crates/cli/src/fingerprint.rs
@@ -1,0 +1,63 @@
+use anyhow::Result;
+use sightglass_data::Format;
+use sightglass_fingerprint::{Benchmark, Engine, Machine};
+use std::{io, path::PathBuf};
+use structopt::StructOpt;
+
+/// Gather information about the current machine, a Wasm benchmark, or a Wasm
+/// engine and print the results to `stdout`.
+#[derive(Debug, StructOpt)]
+#[structopt(name = "fingerprint")]
+pub struct FingerprintCommand {
+    /// The kind of item to fingerprint. One of: 'benchmark', 'engine', 'machine'.
+    #[structopt(short = "k", long = "kind")]
+    kind: Kind,
+
+    /// The format of the output data. Either 'json' or 'csv'.
+    #[structopt(short = "o", long = "output-format", default_value = "json")]
+    output_format: Format,
+
+    /// The optional path to the file to fingerprint; not all kinds
+    /// fingerprinting require a file (e.g., `--kind machine`).
+    #[structopt(index = 1, value_name = "FILE", parse(from_os_str))]
+    file: Option<PathBuf>,
+}
+
+impl FingerprintCommand {
+    pub fn execute(&self) -> Result<()> {
+        let out = io::stdout();
+        match self.kind {
+            Kind::Machine => self.output_format.write_one(Machine::fingerprint()?, out),
+            Kind::Engine => {
+                let file = self.file.as_ref().expect("an engine file must be passed");
+                self.output_format
+                    .write_one(Engine::fingerprint(file)?, out)
+            }
+            Kind::Benchmark => {
+                let file = self.file.as_ref().expect("a benchmark file must be passed");
+                self.output_format
+                    .write_one(Benchmark::fingerprint(file)?, out)
+            }
+        }
+    }
+}
+
+/// The kinds of Sightglass items that can be fingerprinted.
+#[derive(Clone, Debug)]
+enum Kind {
+    Machine,
+    Engine,
+    Benchmark,
+}
+
+impl std::str::FromStr for Kind {
+    type Err = &'static str;
+    fn from_str(s: &str) -> Result<Self, &'static str> {
+        match s {
+            "machine" => Ok(Kind::Machine),
+            "engine" => Ok(Kind::Engine),
+            "benchmark" => Ok(Kind::Benchmark),
+            _ => Err("output format must be one of: 'machine', 'engine', 'benchmark'"),
+        }
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod benchmark;
 mod build_benchmark;
 mod effect_size;
+mod fingerprint;
 mod summarize;
 mod validate;
 
@@ -8,6 +9,7 @@ use anyhow::Result;
 use benchmark::BenchmarkCommand;
 use build_benchmark::BuildBenchmarkCommand;
 use effect_size::EffectSizeCommand;
+use fingerprint::FingerprintCommand;
 use log::trace;
 use structopt::{clap::AppSettings, StructOpt};
 use summarize::SummarizeCommand;
@@ -36,6 +38,7 @@ enum SightglassCommand {
     Validate(ValidateCommand),
     Summarize(SummarizeCommand),
     EffectSize(EffectSizeCommand),
+    Fingerprint(FingerprintCommand),
 }
 
 impl SightglassCommand {
@@ -47,6 +50,7 @@ impl SightglassCommand {
             SightglassCommand::Validate(validate) => validate.execute(),
             SightglassCommand::Summarize(summarize) => summarize.execute(),
             SightglassCommand::EffectSize(effect_size) => effect_size.execute(),
+            SightglassCommand::Fingerprint(fingerprint) => fingerprint.execute(),
         }
     }
 }

--- a/crates/cli/tests/all/benchmark.rs
+++ b/crates/cli/tests/all/benchmark.rs
@@ -1,83 +1,8 @@
+use super::util::{benchmark, sightglass_cli, sightglass_cli_benchmark, test_engine};
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use sightglass_data::Measurement;
 use std::path::PathBuf;
-use std::process::Command;
-
-/// Get a `Command` for this crate's `sightglass-cli` executable.
-fn sightglass_cli() -> Command {
-    drop(env_logger::try_init());
-    Command::cargo_bin("sightglass-cli").unwrap()
-}
-
-/// Get the path to the engine we are testing with.
-fn test_engine() -> PathBuf {
-    if let Ok(engine) = std::env::var("SIGHTGLASS_TEST_ENGINE") {
-        // Use the engine specified by the environment variable. We use this to
-        // cache built `libwasmtime_bench_api.so`s in CI.
-        engine.into()
-    } else {
-        // Make sure we only ever build Wasmtime once, and don't have N threads
-        // build it in parallel and race to be the one to save it onto the file
-        // system.
-        let project_dir = PathBuf::from("../..").canonicalize().unwrap();
-        let engine_dir = project_dir.join("engines/wasmtime");
-        let engine_path = engine_dir.join(sightglass_build::get_engine_filename());
-        static BUILD_WASMTIME: std::sync::Once = std::sync::Once::new();
-        BUILD_WASMTIME.call_once(|| {
-            if engine_path.is_file() {
-                // Use the already built engine library.
-                return;
-            } else {
-                // Use this instead of `eprintln!` to avoid `cargo test`'s stdio
-                // capturing.
-                use std::io::Write;
-                drop(writeln!(
-                    std::io::stderr(),
-                    "**************************************************************\n\
-                 *** Building Wasmtime engine; this may take a few minutes. ***\n\
-                 **************************************************************"
-                ));
-
-                // Build the `build.rs` script.
-                let status = Command::new("rustc")
-                    .current_dir(&engine_dir)
-                    .arg("build.rs")
-                    .status()
-                    .expect("failed to run `rustc build.rs`");
-                assert!(status.success());
-
-                // Build the Wasmtime engine library in to the `engines/wasmtime` directory.
-                let build_script_path =
-                    engine_dir.join(format!("build{}", std::env::consts::EXE_SUFFIX));
-                let status = Command::new(build_script_path)
-                    .current_dir(&engine_dir)
-                    .status()
-                    .expect("failed to run `./build`");
-                assert!(status.success());
-            }
-        });
-        engine_path
-    }
-}
-
-/// Get a `sightglass-cli benchmark` command that is configured to use our test
-/// engine.
-fn sightglass_cli_benchmark() -> Command {
-    let mut cmd = sightglass_cli();
-    cmd.arg("benchmark").arg("--engine").arg(test_engine());
-    cmd
-}
-
-/// Get the benchmark path for the benchmark with the given name.
-fn benchmark(benchmark_name: &str) -> String {
-    format!("../../benchmarks-next/{}/benchmark.wasm", benchmark_name).into()
-}
-
-#[test]
-fn help() {
-    sightglass_cli().arg("help").assert().success();
-}
 
 #[test]
 fn benchmark_stop_after_compilation() {

--- a/crates/cli/tests/all/fingerprint.rs
+++ b/crates/cli/tests/all/fingerprint.rs
@@ -36,10 +36,11 @@ fn fingerprint_benchmark() {
         drop(measurement.unwrap());
     }
 
+    let benchmark_subpath = format!("noop{}benchmark.wasm", std::path::MAIN_SEPARATOR);
     assert
         .stdout(
             predicate::str::starts_with("name,path,hash,size\n")
-                .and(predicate::str::contains("noop/benchmark.wasm")),
+                .and(predicate::str::contains(benchmark_subpath)),
         )
         .success();
 }

--- a/crates/cli/tests/all/fingerprint.rs
+++ b/crates/cli/tests/all/fingerprint.rs
@@ -64,12 +64,14 @@ fn fingerprint_engine() {
         drop(measurement.unwrap());
     }
 
+    // On Windows, the paths will have extra escaping when printed to output.
+    let escaped_engine_path = engine_path.to_string_lossy().replace("\\", "\\\\");
     use predicate::str::*;
     assert
         .stdout(
             starts_with("{")
                 .and(contains(r#""name":"wasmtime-"#))
-                .and(contains(format!("\"path\":\"{}\"", engine_path.display())))
+                .and(contains(format!(r#""path":"{}""#, escaped_engine_path)))
                 .and(contains(r#""buildinfo":"NAME=wasmtime"#))
                 .and(ends_with("}")),
         )

--- a/crates/cli/tests/all/fingerprint.rs
+++ b/crates/cli/tests/all/fingerprint.rs
@@ -70,7 +70,7 @@ fn fingerprint_engine() {
             starts_with("{")
                 .and(contains(r#""name":"wasmtime-"#))
                 .and(contains(format!(r#""path":"{}""#, engine_path.display())))
-                .and(contains(r#""buildinfo":"NAME=wasmtime\n"#))
+                .and(contains(r#""buildinfo":"NAME=wasmtime"#))
                 .and(ends_with("}")),
         )
         .success();

--- a/crates/cli/tests/all/fingerprint.rs
+++ b/crates/cli/tests/all/fingerprint.rs
@@ -69,7 +69,7 @@ fn fingerprint_engine() {
         .stdout(
             starts_with("{")
                 .and(contains(r#""name":"wasmtime-"#))
-                //.and(contains(format!(r#""path":"{}""#, engine_path.display())))
+                .and(contains(format!("\"path\":\"{}\"", engine_path.display())))
                 .and(contains(r#""buildinfo":"NAME=wasmtime"#))
                 .and(ends_with("}")),
         )

--- a/crates/cli/tests/all/fingerprint.rs
+++ b/crates/cli/tests/all/fingerprint.rs
@@ -69,7 +69,7 @@ fn fingerprint_engine() {
         .stdout(
             starts_with("{")
                 .and(contains(r#""name":"wasmtime-"#))
-                .and(contains(format!(r#""path":"{}""#, engine_path.display())))
+                //.and(contains(format!(r#""path":"{}""#, engine_path.display())))
                 .and(contains(r#""buildinfo":"NAME=wasmtime"#))
                 .and(ends_with("}")),
         )

--- a/crates/cli/tests/all/fingerprint.rs
+++ b/crates/cli/tests/all/fingerprint.rs
@@ -1,0 +1,76 @@
+//! Test `sightglass-cli fingerprint`.
+
+use super::util::{benchmark, sightglass_cli, test_engine};
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use sightglass_fingerprint::{Benchmark, Machine};
+
+#[test]
+fn fingerprint_machine() {
+    let assert = sightglass_cli()
+        .arg("fingerprint")
+        .arg("--kind")
+        .arg("machine")
+        .assert();
+
+    let stdout = std::str::from_utf8(&assert.get_output().stdout).unwrap();
+    eprintln!("=== stdout ===\n{}\n===========", stdout);
+    assert!(serde_json::from_str::<Machine>(stdout).is_ok());
+}
+
+#[test]
+fn fingerprint_benchmark() {
+    let assert = sightglass_cli()
+        .arg("fingerprint")
+        .arg("--kind")
+        .arg("benchmark")
+        .arg("--output-format")
+        .arg("csv")
+        .arg(benchmark("noop"))
+        .assert();
+
+    let stdout = std::str::from_utf8(&assert.get_output().stdout).unwrap();
+    eprintln!("=== stdout ===\n{}\n===========", stdout);
+    let mut reader = csv::Reader::from_reader(stdout.as_bytes());
+    for measurement in reader.deserialize::<Benchmark>() {
+        drop(measurement.unwrap());
+    }
+
+    assert
+        .stdout(
+            predicate::str::starts_with("name,path,hash,size\n")
+                .and(predicate::str::contains("noop/benchmark.wasm")),
+        )
+        .success();
+}
+
+#[test]
+fn fingerprint_engine() {
+    let engine_path = test_engine();
+    let assert = sightglass_cli()
+        .arg("fingerprint")
+        .arg("--kind")
+        .arg("engine")
+        .arg("--output-format")
+        .arg("json")
+        .arg(&engine_path)
+        .assert();
+
+    let stdout = std::str::from_utf8(&assert.get_output().stdout).unwrap();
+    eprintln!("=== stdout ===\n{}\n===========", stdout);
+    let mut reader = csv::Reader::from_reader(stdout.as_bytes());
+    for measurement in reader.deserialize::<Benchmark>() {
+        drop(measurement.unwrap());
+    }
+
+    use predicate::str::*;
+    assert
+        .stdout(
+            starts_with("{")
+                .and(contains(r#""name":"wasmtime-"#))
+                .and(contains(format!(r#""path":"{}""#, engine_path.display())))
+                .and(contains(r#""buildinfo":"NAME=wasmtime\n"#))
+                .and(ends_with("}")),
+        )
+        .success();
+}

--- a/crates/cli/tests/all/help.rs
+++ b/crates/cli/tests/all/help.rs
@@ -1,0 +1,7 @@
+use super::util::sightglass_cli;
+use assert_cmd::prelude::*;
+
+#[test]
+fn help() {
+    sightglass_cli().arg("help").assert().success();
+}

--- a/crates/cli/tests/all/main.rs
+++ b/crates/cli/tests/all/main.rs
@@ -1,0 +1,6 @@
+mod benchmark;
+mod fingerprint;
+mod help;
+mod util;
+
+fn main() {}

--- a/crates/cli/tests/all/util.rs
+++ b/crates/cli/tests/all/util.rs
@@ -1,0 +1,71 @@
+use assert_cmd::prelude::*;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Get a `Command` for this crate's `sightglass-cli` executable.
+pub fn sightglass_cli() -> Command {
+    drop(env_logger::try_init());
+    Command::cargo_bin("sightglass-cli").unwrap()
+}
+/// Get the path to the engine we are testing with.
+pub fn test_engine() -> PathBuf {
+    if let Ok(engine) = std::env::var("SIGHTGLASS_TEST_ENGINE") {
+        // Use the engine specified by the environment variable. We use this to
+        // cache built `libwasmtime_bench_api.so`s in CI.
+        engine.into()
+    } else {
+        // Make sure we only ever build Wasmtime once, and don't have N threads
+        // build it in parallel and race to be the one to save it onto the file
+        // system.
+        let project_dir = PathBuf::from("../..").canonicalize().unwrap();
+        let engine_dir = project_dir.join("engines/wasmtime");
+        let engine_path = engine_dir.join(sightglass_build::get_engine_filename());
+        static BUILD_WASMTIME: std::sync::Once = std::sync::Once::new();
+        BUILD_WASMTIME.call_once(|| {
+            if engine_path.is_file() {
+                // Use the already built engine library.
+                return;
+            } else {
+                // Use this instead of `eprintln!` to avoid `cargo test`'s stdio
+                // capturing.
+                use std::io::Write;
+                drop(writeln!(
+                    std::io::stderr(),
+                    "**************************************************************\n\
+                 *** Building Wasmtime engine; this may take a few minutes. ***\n\
+                 **************************************************************"
+                ));
+
+                // Build the `build.rs` script.
+                let status = Command::new("rustc")
+                    .current_dir(&engine_dir)
+                    .arg("build.rs")
+                    .status()
+                    .expect("failed to run `rustc build.rs`");
+                assert!(status.success());
+
+                // Build the Wasmtime engine library in to the `engines/wasmtime` directory.
+                let build_script_path =
+                    engine_dir.join(format!("build{}", std::env::consts::EXE_SUFFIX));
+                let status = Command::new(build_script_path)
+                    .current_dir(&engine_dir)
+                    .status()
+                    .expect("failed to run `./build`");
+                assert!(status.success());
+            }
+        });
+        engine_path
+    }
+}
+
+/// Get a `sightglass-cli benchmark` command that is configured to use our test engine.
+pub fn sightglass_cli_benchmark() -> Command {
+    let mut cmd = sightglass_cli();
+    cmd.arg("benchmark").arg("--engine").arg(test_engine());
+    cmd
+}
+
+/// Get the benchmark path for the benchmark with the given name.
+pub fn benchmark(benchmark_name: &str) -> String {
+    format!("../../benchmarks-next/{}/benchmark.wasm", benchmark_name).into()
+}

--- a/crates/data/src/format.rs
+++ b/crates/data/src/format.rs
@@ -65,6 +65,24 @@ impl Format {
             }
         })
     }
+
+    /// Write a list of `T` using the selected format.
+    pub fn write_one<T, W>(&self, object: T, writer: W) -> Result<()>
+    where
+        T: Serialize,
+        W: Write + Sized,
+    {
+        Ok(match self {
+            Format::Json => serde_json::to_writer(writer, &object)?,
+            Format::Csv { headers } => {
+                let mut csv = csv::WriterBuilder::new()
+                    .has_headers(headers.take())
+                    .from_writer(writer);
+                csv.serialize(&object)?;
+                csv.flush()?;
+            }
+        })
+    }
 }
 
 impl fmt::Display for Format {

--- a/crates/fingerprint/Cargo.toml
+++ b/crates/fingerprint/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sightglass-fingerprint"
+version = "0.1.0"
+description = "Collect metadata for various parts of Sightglass"
+authors = ["Sightglass Project Developers"]
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+bytesize = "1.1"
+hostname = "0.3"
+log = "0.4"
+os_info = "3.2"
+regex = "1.5"
+serde = { version = "1.0.136", features = ["derive"] }
+sha2 = "0.10"
+sightglass-build = { path = "../build" }
+sysinfo = "0.23"

--- a/crates/fingerprint/src/benchmark.rs
+++ b/crates/fingerprint/src/benchmark.rs
@@ -1,5 +1,5 @@
 use crate::hash;
-use crate::util::stringify;
+use crate::util::to_string_lossy;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -65,7 +65,7 @@ fn simplify_benchmark_name<P: AsRef<Path>>(path: P) -> Result<String> {
     } else {
         stem
     };
-    Ok(stringify(name))
+    Ok(to_string_lossy(name))
 }
 
 /// Simplify the benchmark path if possible; e.g.:
@@ -79,9 +79,9 @@ fn simplify_benchmark_path<P: AsRef<Path>>(path: P) -> String {
         .position(|c| c == "benchmarks" || c == "benchmarks-next")
     {
         let shortened_path: PathBuf = path.iter().skip(i).collect();
-        stringify(shortened_path.as_os_str())
+        to_string_lossy(shortened_path.as_os_str())
     } else {
-        stringify(path.as_os_str())
+        to_string_lossy(path.as_os_str())
     }
 }
 

--- a/crates/fingerprint/src/benchmark.rs
+++ b/crates/fingerprint/src/benchmark.rs
@@ -11,7 +11,7 @@ use std::{fs::File, path::Path};
 /// # use sightglass_fingerprint::Benchmark;
 /// let benchmark = Benchmark::fingerprint("../../benchmarks-next/noop/benchmark.wasm").unwrap();
 /// assert_eq!(benchmark.name, "noop");
-/// assert_eq!(benchmark.path, "benchmarks-next/noop/benchmark.wasm");
+/// assert_eq!(benchmark.path, format!("benchmarks-next{}noop{}benchmark.wasm", std::path::MAIN_SEPARATOR, std::path::MAIN_SEPARATOR));
 /// ```
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Benchmark {
@@ -71,9 +71,7 @@ fn simplify_benchmark_name<P: AsRef<Path>>(path: P) -> Result<String> {
 /// Simplify the benchmark path if possible; e.g.:
 /// `/home/user/code/sightglass/benchmarks-next/<name>/benchmark.wasm` ->
 /// `benchmarks-next/<name>/benchmark.wasm`. This function finds a path component matching
-/// `benchmarks/` or `benchmarks-next/` and cuts the path there. To avoid OS path differences, the
-/// simplified name will have its back slashes replaced with forward slashes; not-simplified paths
-/// remain the same.
+/// `benchmarks/` or `benchmarks-next/` and cuts the path there.
 fn simplify_benchmark_path<P: AsRef<Path>>(path: P) -> String {
     let path = path.as_ref();
     if let Some(i) = path
@@ -81,7 +79,7 @@ fn simplify_benchmark_path<P: AsRef<Path>>(path: P) -> String {
         .position(|c| c == "benchmarks" || c == "benchmarks-next")
     {
         let shortened_path: PathBuf = path.iter().skip(i).collect();
-        to_string_lossy(shortened_path.as_os_str()).replace("\\", "/")
+        to_string_lossy(shortened_path.as_os_str())
     } else {
         to_string_lossy(path.as_os_str())
     }
@@ -104,15 +102,19 @@ mod tests {
     fn shortened_benchmark_paths() {
         assert_eq!(
             simplify_benchmark_path("/home/user/sightglass/benchmarks/benchmark.wasm"),
-            "benchmarks/benchmark.wasm"
+            format!("benchmark{}benchmark.wasm", std::path::MAIN_SEPARATOR)
         );
         assert_eq!(
             simplify_benchmark_path("code/benchmarks-next/noop.wasm"),
-            "benchmarks-next/noop.wasm"
+            format!("benchmarks-next{}noop.wasm", std::path::MAIN_SEPARATOR)
         );
         assert_eq!(
             simplify_benchmark_path("some/other/path.wasm"),
-            "some/other/path.wasm"
+            format!(
+                "some{}other{}path.wasm",
+                std::path::MAIN_SEPARATOR,
+                std::path::MAIN_SEPARATOR
+            )
         );
     }
 }

--- a/crates/fingerprint/src/benchmark.rs
+++ b/crates/fingerprint/src/benchmark.rs
@@ -102,7 +102,7 @@ mod tests {
     fn shortened_benchmark_paths() {
         assert_eq!(
             simplify_benchmark_path("/home/user/sightglass/benchmarks/benchmark.wasm"),
-            format!("benchmark{}benchmark.wasm", std::path::MAIN_SEPARATOR)
+            format!("benchmarks{}benchmark.wasm", std::path::MAIN_SEPARATOR)
         );
         assert_eq!(
             simplify_benchmark_path("code/benchmarks-next/noop.wasm"),

--- a/crates/fingerprint/src/benchmark.rs
+++ b/crates/fingerprint/src/benchmark.rs
@@ -108,13 +108,10 @@ mod tests {
             simplify_benchmark_path("code/benchmarks-next/noop.wasm"),
             format!("benchmarks-next{}noop.wasm", std::path::MAIN_SEPARATOR)
         );
+        // Note here how `simplify_benchmark_path` does not modify the path separator.
         assert_eq!(
             simplify_benchmark_path("some/other/path.wasm"),
-            format!(
-                "some{}other{}path.wasm",
-                std::path::MAIN_SEPARATOR,
-                std::path::MAIN_SEPARATOR
-            )
+            "some/other/path.wasm"
         );
     }
 }

--- a/crates/fingerprint/src/benchmark.rs
+++ b/crates/fingerprint/src/benchmark.rs
@@ -15,7 +15,7 @@ use std::{fs::File, path::Path};
 /// ```
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Benchmark {
-    /// The benchmark name; this is calculated from either the benchark name (if it does not start
+    /// The benchmark name; this is calculated from either the benchmark name (if it does not start
     /// with "benchmark") or from the parent directory. This accommodates both the current benchmark
     /// structure where each directory contains a "benchmark.wasm" file as well as non-Sightglass
     /// benchmarks, e.g., "spidermonkey.wasm".
@@ -70,8 +70,10 @@ fn simplify_benchmark_name<P: AsRef<Path>>(path: P) -> Result<String> {
 
 /// Simplify the benchmark path if possible; e.g.:
 /// `/home/user/code/sightglass/benchmarks-next/<name>/benchmark.wasm` ->
-/// `benchmarks-next/<name>/benchmark.wasm`. This function finds a path component natching
-/// `benchmarks/` or `benchmarks-next/` and cuts the path there.
+/// `benchmarks-next/<name>/benchmark.wasm`. This function finds a path component matching
+/// `benchmarks/` or `benchmarks-next/` and cuts the path there. To avoid OS path differences, the
+/// simplified name will have its back slashes replaced with forward slashes; not-simplified paths
+/// remain the same.
 fn simplify_benchmark_path<P: AsRef<Path>>(path: P) -> String {
     let path = path.as_ref();
     if let Some(i) = path
@@ -79,7 +81,7 @@ fn simplify_benchmark_path<P: AsRef<Path>>(path: P) -> String {
         .position(|c| c == "benchmarks" || c == "benchmarks-next")
     {
         let shortened_path: PathBuf = path.iter().skip(i).collect();
-        to_string_lossy(shortened_path.as_os_str())
+        to_string_lossy(shortened_path.as_os_str()).replace("\\", "/")
     } else {
         to_string_lossy(path.as_os_str())
     }

--- a/crates/fingerprint/src/benchmark.rs
+++ b/crates/fingerprint/src/benchmark.rs
@@ -1,0 +1,116 @@
+use crate::hash;
+use crate::util::stringify;
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::{fs::File, path::Path};
+
+/// Describes a fingerprinted benchmark.
+///
+/// ```
+/// # use sightglass_fingerprint::Benchmark;
+/// let benchmark = Benchmark::fingerprint("../../benchmarks-next/noop/benchmark.wasm").unwrap();
+/// assert_eq!(benchmark.name, "noop");
+/// assert_eq!(benchmark.path, "benchmarks-next/noop/benchmark.wasm");
+/// ```
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct Benchmark {
+    /// The benchmark name; this is calculated from either the benchark name (if it does not start
+    /// with "benchmark") or from the parent directory. This accommodates both the current benchmark
+    /// structure where each directory contains a "benchmark.wasm" file as well as non-Sightglass
+    /// benchmarks, e.g., "spidermonkey.wasm".
+    pub name: String,
+    /// The path to the benchmark on the system.
+    pub path: String,
+    /// The SHA256 hash of the benchmark file.
+    pub hash: String,
+    /// The size of the file; this may be useful for comparing compile times between benchmarks of
+    /// different sizes.
+    pub size: u64,
+}
+
+impl Benchmark {
+    pub fn fingerprint<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref().canonicalize()?;
+
+        // Calculate the hash for the benchmark file.
+        let size = File::open(&path)
+            .expect("should be able to open the benchmark file")
+            .metadata()
+            .expect("should be able to collect the benchmark file size")
+            .len();
+
+        Ok(Self {
+            name: simplify_benchmark_name(&path)?,
+            path: simplify_benchmark_path(&path),
+            hash: hash::file(&path),
+            size,
+        })
+    }
+}
+
+/// Simplify the benchmark name if possible; e.g.:
+/// - `.../<name>/benchmark.wasm` -> <name>
+/// - `.../<name>.wasm -> <name>
+fn simplify_benchmark_name<P: AsRef<Path>>(path: P) -> Result<String> {
+    let path = path.as_ref();
+    let stem = path
+        .file_stem()
+        .ok_or(anyhow!("the benchmark must have a file name"))?;
+    let name = if stem == "benchmark" {
+        path.parent()
+            .ok_or(anyhow!("the benchmark must have a parent directory"))?
+            .file_name()
+            .ok_or(anyhow!("the parent directory to have a name"))?
+    } else {
+        stem
+    };
+    Ok(stringify(name))
+}
+
+/// Simplify the benchmark path if possible; e.g.:
+/// `/home/user/code/sightglass/benchmarks-next/<name>/benchmark.wasm` ->
+/// `benchmarks-next/<name>/benchmark.wasm`. This function finds a path component natching
+/// `benchmarks/` or `benchmarks-next/` and cuts the path there.
+fn simplify_benchmark_path<P: AsRef<Path>>(path: P) -> String {
+    let path = path.as_ref();
+    if let Some(i) = path
+        .iter()
+        .position(|c| c == "benchmarks" || c == "benchmarks-next")
+    {
+        let shortened_path: PathBuf = path.iter().skip(i).collect();
+        stringify(shortened_path.as_os_str())
+    } else {
+        stringify(path.as_os_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shortened_benchmark_names() {
+        assert_eq!(
+            simplify_benchmark_name("benchmarks-next/noop/benchmark.wasm").unwrap(),
+            "noop"
+        );
+        assert_eq!(simplify_benchmark_name("a/b/c.wasm").unwrap(), "c");
+    }
+
+    #[test]
+    fn shortened_benchmark_paths() {
+        assert_eq!(
+            simplify_benchmark_path("/home/user/sightglass/benchmarks/benchmark.wasm"),
+            "benchmarks/benchmark.wasm"
+        );
+        assert_eq!(
+            simplify_benchmark_path("code/benchmarks-next/noop.wasm"),
+            "benchmarks-next/noop.wasm"
+        );
+        assert_eq!(
+            simplify_benchmark_path("some/other/path.wasm"),
+            "some/other/path.wasm"
+        );
+    }
+}

--- a/crates/fingerprint/src/engine.rs
+++ b/crates/fingerprint/src/engine.rs
@@ -1,5 +1,5 @@
 use crate::hash;
-use crate::util::stringify;
+use crate::util::to_string_lossy;
 use anyhow::{anyhow, Result};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -26,7 +26,7 @@ impl Engine {
     pub fn fingerprint<P: AsRef<Path>>(library_path: P) -> Result<Self> {
         let library_path = library_path.as_ref().canonicalize()?;
         let buildinfo_path = get_buildinfo_path_from_engine_path(&library_path)?;
-        let path = stringify(&library_path);
+        let path = to_string_lossy(&library_path);
 
         if let Ok(buildinfo_contents) = fs::read_to_string(buildinfo_path) {
             let buildinfo_name = extract_value_from_buildinfo(&buildinfo_contents, "NAME")

--- a/crates/fingerprint/src/engine.rs
+++ b/crates/fingerprint/src/engine.rs
@@ -1,0 +1,104 @@
+use crate::hash;
+use crate::util::stringify;
+use anyhow::{anyhow, Result};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DEFAULT_NAME: &str = "custom";
+
+/// Describes a WebAssembly engine.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct Engine {
+    /// The canonical name for the engine; e.g.:
+    /// - `wasmtime-<build info hash>` for an engine with a NAME in the build info
+    /// - `custom-<library hash>` for a pre-built engine at a given path
+    pub name: String,
+    /// The path to the engine.
+    pub path: String,
+    /// Describes the known configuration when building the engine using Sightglass.
+    pub buildinfo: Option<String>,
+}
+
+impl Engine {
+    /// Extract the build information of a Sightglass engine.
+    pub fn fingerprint<P: AsRef<Path>>(library_path: P) -> Result<Self> {
+        let library_path = library_path.as_ref().canonicalize()?;
+        let buildinfo_path = get_buildinfo_path_from_engine_path(&library_path)?;
+        let path = stringify(&library_path);
+
+        if let Ok(buildinfo_contents) = fs::read_to_string(buildinfo_path) {
+            let buildinfo_name = extract_value_from_buildinfo(&buildinfo_contents, "NAME")
+                .unwrap_or(DEFAULT_NAME.into());
+            let name = format!(
+                "{}-{}",
+                buildinfo_name,
+                hash::slug(&hash::string(&buildinfo_contents))
+            );
+            Ok(Self {
+                name,
+                path,
+                buildinfo: Some(buildinfo_contents),
+            })
+        } else {
+            log::warn!(
+                "No .build-info for the engine at: {}",
+                &library_path.display()
+            );
+            Ok(Self {
+                name: format!(
+                    "{}-{}",
+                    DEFAULT_NAME,
+                    hash::slug(&hash::file(&library_path))
+                ),
+                path,
+                buildinfo: None,
+            })
+        }
+    }
+}
+
+/// Calculate the path to a built engine's BUILD-INFO file.
+pub fn get_buildinfo_path_from_engine_path(engine_path: &Path) -> Result<PathBuf> {
+    Ok(engine_path
+        .parent()
+        .ok_or(anyhow!("engine should have a parent directory"))?
+        .join(".build-info"))
+}
+
+/// Calculate the path to a built engine's BUILD-INFO file.
+pub fn extract_value_from_buildinfo(buildinfo: &str, key: &str) -> Option<String> {
+    let re = Regex::new(&format!("(?m)^ *{} *= *([[:alnum:]]+) *", key)).unwrap();
+    for cap in re.captures_iter(buildinfo) {
+        return Some(cap[1].to_string());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_buildinfo_file() {
+        let engine_path = PathBuf::from("/some/libengine.so");
+        let buildinfo_path = get_buildinfo_path_from_engine_path(&engine_path).unwrap();
+        assert_eq!(buildinfo_path, PathBuf::from("/some/.build-info"));
+    }
+
+    #[test]
+    fn find_name_in_buildinfo() {
+        let buildinfo = r#"
+        ...
+        SOME_NAME_KEY=1
+        ANOTHER_NAME=...
+        NAME=wasmtime
+        ...
+        "#;
+        assert_eq!(
+            extract_value_from_buildinfo(buildinfo, "NAME"),
+            Some("wasmtime".to_string())
+        );
+    }
+}

--- a/crates/fingerprint/src/hash.rs
+++ b/crates/fingerprint/src/hash.rs
@@ -29,7 +29,7 @@ pub(crate) fn hexify(bytes: &[u8]) -> String {
     s
 }
 
-/// Create a hexadecimal string from a sequence of bytes.
+/// Use the first 8 characters of a string as its slug; e.g., for hashes.
 pub fn slug(s: &str) -> &str {
     &s[0..8]
 }

--- a/crates/fingerprint/src/hash.rs
+++ b/crates/fingerprint/src/hash.rs
@@ -1,0 +1,35 @@
+//! Provide a consistent way for hashing build files and strings.
+use sha2::{Digest, Sha256};
+use std::{fs::File, io, path::Path};
+
+/// Calculate the SHA256 hash of a file.
+pub fn file<P: AsRef<Path>>(path: P) -> String {
+    let mut file = File::open(&path).expect("the benchmark to be a file that can be opened");
+    let mut hasher = Sha256::new();
+    let _ = io::copy(&mut file, &mut hasher).expect("to be able to hash the benchmark bytes");
+    let hash = hasher.finalize();
+    hexify(hash.as_slice())
+}
+
+/// Calculate the SHA256 hash of a string.
+pub(crate) fn string(data: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let hash = hasher.finalize();
+    hexify(hash.as_slice())
+}
+
+/// Create a hexadecimal string from a sequence of bytes.
+pub(crate) fn hexify(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut s = String::new();
+    for byte in bytes {
+        write!(&mut s, "{:x}", byte).expect("unable to write byte as hex");
+    }
+    s
+}
+
+/// Create a hexadecimal string from a sequence of bytes.
+pub fn slug(s: &str) -> &str {
+    &s[0..8]
+}

--- a/crates/fingerprint/src/lib.rs
+++ b/crates/fingerprint/src/lib.rs
@@ -1,0 +1,11 @@
+//! Provide a way to gather metadata about various parts of the Sightglass framework.
+
+mod benchmark;
+mod engine;
+mod hash;
+mod machine;
+mod util;
+
+pub use benchmark::Benchmark;
+pub use engine::Engine;
+pub use machine::Machine;

--- a/crates/fingerprint/src/machine.rs
+++ b/crates/fingerprint/src/machine.rs
@@ -1,0 +1,66 @@
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use sysinfo::{ProcessorExt, System, SystemExt};
+
+/// Describes a fingerprinted system.
+///
+/// ```
+/// # use sightglass_fingerprint::Machine;
+/// println!("Current machine fingerprint: {:?}", Machine::fingerprint());
+/// ```
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct Machine {
+    /// The host name of the machine.
+    pub name: String,
+    /// The long version of the system OS; e.g., Linux 35 Fedora Linux.
+    pub os: String,
+    /// The system's kernel version; e.g., 5.15.14
+    pub kernel: String,
+    /// The system's CPU architecture.
+    pub arch: String,
+    /// The CPU brand string; e.g., like `lscpu`'s model name.
+    pub cpu: String,
+    /// The amount of system memory in a human-readable string; e.g. 4 GiB.
+    pub memory: String,
+}
+
+impl Machine {
+    /// Detect system information for the currently machine running Sightglass.
+    pub fn fingerprint() -> Result<Self> {
+        // Gather the host name.
+        let name = hostname::get()
+            .expect("must be able to detect the system hostname")
+            .to_string_lossy()
+            .to_string();
+
+        // Gather the OS information.
+        let mut sys = System::new();
+        let os = sys
+            .long_os_version()
+            .ok_or(anyhow!("must be able to detect the system OS"))?;
+        let kernel = sys
+            .kernel_version()
+            .ok_or(anyhow!("must be able to detect the system kernel version"))?;
+
+        // Gather some CPU information.
+        let arch = std::env::consts::ARCH.to_string();
+        sys.refresh_cpu();
+        let cpu = sys.global_processor_info().brand().to_string();
+
+        // Gather the memory information. The expected result should be in GiB (the 1024-base SI
+        // measurement commonly used for memory) but it is unclear whether `sysinfo` is returning KB
+        // or KiB.
+        sys.refresh_memory();
+        let memory_total_kb = sys.total_memory();
+        let memory = bytesize::to_string(bytesize::ByteSize::kib(memory_total_kb).0, true);
+
+        Ok(Self {
+            name,
+            arch,
+            os,
+            kernel,
+            cpu,
+            memory,
+        })
+    }
+}

--- a/crates/fingerprint/src/util.rs
+++ b/crates/fingerprint/src/util.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsStr;
 
 /// Provide a common way to create `String`s from `OsStr`.
-pub(crate) fn stringify<S: AsRef<OsStr>>(s: S) -> String {
+pub(crate) fn to_string_lossy<S: AsRef<OsStr>>(s: S) -> String {
     s.as_ref().to_string_lossy().to_string()
 }

--- a/crates/fingerprint/src/util.rs
+++ b/crates/fingerprint/src/util.rs
@@ -1,0 +1,6 @@
+use std::ffi::OsStr;
+
+/// Provide a common way to create `String`s from `OsStr`.
+pub(crate) fn stringify<S: AsRef<OsStr>>(s: S) -> String {
+    s.as_ref().to_string_lossy().to_string()
+}


### PR DESCRIPTION
This new command adds the ability to collect additional information
about several Sightglass components:
- `--kind machine` collects system information, e.g., OS, CPU, etc.
- `--kind benchmark` calculates a shortened benchmark name and hashes
  the Wasm contents
- `--kind engine` collects information about the Wasm engine, e.g., how
  it was built and what flags it uses