### PR TITLE
Port the ability to pin to a single core from the legacy runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1635,6 +1635,8 @@ name = "sightglass-recorder"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "core_affinity",
+ "hwloc",
  "ittapi",
  "lazy_static",
  "libc",

--- a/crates/recorder/Cargo.toml
+++ b/crates/recorder/Cargo.toml
@@ -22,6 +22,12 @@ perf-event = "0.4"
 # On supported platforms, we use libc's `sched_getcpu` to log the processor ID.
 libc = "0.2"
 
+# There are multiple implementations for pinning the benchmark to a single core.
+[target.'cfg(any(target_os="windows",target_os="macos",target_os="linux"))'.dependencies]
+core_affinity="0.5.9"
+[target.'cfg(not(any(target_os="windows",target_os="macos",target_os="linux")))'.dependencies]
+hwloc = "0.5"
+
 [dev-dependencies]
 pretty_env_logger = "0.4"
 wat = "1.0"

--- a/crates/recorder/src/cpu_affinity/affinity_core_affinity.rs
+++ b/crates/recorder/src/cpu_affinity/affinity_core_affinity.rs
@@ -1,0 +1,9 @@
+use anyhow::{anyhow, Result};
+
+/// Bind the current thread to a single CPU core.
+pub fn bind_to_single_core() -> Result<()> {
+    let core_ids = core_affinity::get_core_ids().ok_or(anyhow!("empty CPU set"))?;
+    let last_core = core_ids.last().ok_or(anyhow!("zero CPU cores detected"))?;
+    core_affinity::set_for_current(*last_core);
+    Ok(())
+}

--- a/crates/recorder/src/cpu_affinity/affinity_hwloc.rs
+++ b/crates/recorder/src/cpu_affinity/affinity_hwloc.rs
@@ -1,0 +1,19 @@
+use anyhow::{anyhow, Result};
+use hwloc::{ObjectType, Topology, TopologyObject};
+
+/// Bind the current thread to a single CPU core.
+pub fn bind_to_single_core() -> Result<()> {
+    let mut topo = Topology::new();
+    let mut cpuset = last_core(&mut topo)?
+        .cpuset()
+        .ok_or(anyhow!("empty CPU set"))?;
+    cpuset.singlify();
+    Ok(())
+}
+
+/// Helper method to find the last core.
+fn last_core(topo: &mut Topology) -> Result<&TopologyObject> {
+    let core_depth = topo.depth_or_below_for_type(&ObjectType::Core).unwrap();
+    let all_cores = topo.objects_at_depth(core_depth);
+    all_cores.last().cloned().ok_or(anyhow!("no cores found"))
+}

--- a/crates/recorder/src/cpu_affinity/mod.rs
+++ b/crates/recorder/src/cpu_affinity/mod.rs
@@ -1,0 +1,15 @@
+// CPU affinity using the `core_affinity` crate.
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+mod affinity_core_affinity;
+
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+pub use affinity_core_affinity::bind_to_single_core;
+
+// CPU affinity using the `hwloc` library.
+
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+mod affinity_hwloc;
+
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+pub use affinity_hwloc::bind_to_single_core;

--- a/crates/recorder/src/lib.rs
+++ b/crates/recorder/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod bench_api;
 pub mod benchmark;
+pub mod cpu_affinity;
 pub mod measure;


### PR DESCRIPTION
In the legacy runner, @jedisct1 added the ability to pin execution to a
single core, using several different mechanisms: it uses the `core_affinity`
crate for common OSes and the `hwloc` crate otherwise. This change ports
that functionality over to the new runner under the `--pin` flag.

This is the last feature that existed in the legacy runner but not in
the new runner (that I could see, at least). Though core-pinning can be
accomplished otherwise, e.g, `taskset --cpu-list 0`, these mechanisms
apply to all subprocesses. It could be possible that a user wants to
benchmark using multiple processes, all on potentially different CPUs,
but have all iterations in that process be pinned to a single core to
avoid measuring context switches.