### PR TITLE
Disable wall time measurement in "wall-cycles" measure; only measure cycles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,9 +772,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "precision"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d13bf03fb02ea18f91430a30f2e53dd7f064445400f16c0d97b17aa2791c2d"
+checksum = "bbc84fc8369453e02d82fe292dc9b03151c80a36716718c0dcc1ff0fe4029a63"
 dependencies = [
  "cc",
  "libc",

--- a/crates/recorder/Cargo.toml
+++ b/crates/recorder/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0"
 libloading = "0.7"
 log = "0.4"
-precision = "0.1"
+precision = "0.1.15"
 serde = { version = "1.0.118", features = ["derive"] }
 sightglass-build = { path = "../build" }
 sightglass-data = { path = "../data" }

--- a/crates/recorder/src/measure/wall_cycles.rs
+++ b/crates/recorder/src/measure/wall_cycles.rs
@@ -7,7 +7,7 @@ use precision::{Config, Precision, Timestamp};
 use sightglass_data::Phase;
 
 lazy_static! {
-    static ref PRECISION: Precision = Precision::new(Config::default()).unwrap();
+    static ref PRECISION: Precision = Precision::new(Config::default().wall_time(false)).unwrap();
 }
 
 pub struct WallCycleMeasure(Option<Timestamp>);
@@ -25,10 +25,12 @@ impl Measure for WallCycleMeasure {
     }
 
     fn end(&mut self, phase: Phase, measurements: &mut Measurements) {
-        let precision = &*PRECISION; // deref the lazy-static just once.
+        // Deref the lazy-static just once.
+        let precision = &*PRECISION;
+
         let end = precision.now();
-        let elapsed = end - self.0.take().expect("an existing timestamp");
+        let elapsed = end - self.0.take().expect("must call start before end");
+
         measurements.add(phase, "cycles".into(), elapsed.ticks());
-        measurements.add(phase, "nanoseconds".into(), elapsed.as_ns(precision));
     }
 }


### PR DESCRIPTION
Rather than the `precision` crate, which is way too over-eager with its
calibration, and often takes 5 seconds to calibrate. This in turn was making
multi-process benchmark measurements way too slow to gather.

`minstant` does not suffer from these problems.