### PR TITLE
Only show "A is 1.23x faster than B!"

### DIFF
--- a/crates/analysis/Cargo.toml
+++ b/crates/analysis/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sightglass-analysis"
 version = "0.1.0"
 authors = ["Sightglass Project Developers"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0.40"

--- a/crates/analysis/src/effect_size.rs
+++ b/crates/analysis/src/effect_size.rs
@@ -127,27 +127,29 @@ pub fn write(
             )?;
             writeln!(output_file)?;
 
-            let ratio = effect_size.b_mean / effect_size.a_mean;
-            let ratio_ci = effect_size.half_width_confidence_interval / effect_size.a_mean;
-            writeln!(
-                output_file,
-                "  {a_engine} is {ratio_min:.2}x to {ratio_max:.2}x faster than {b_engine}!",
-                a_engine = a_engine,
-                b_engine = b_engine,
-                ratio_min = ratio - ratio_ci,
-                ratio_max = ratio + ratio_ci,
-            )?;
-            let ratio = effect_size.a_mean / effect_size.b_mean;
-            let ratio_ci = effect_size.half_width_confidence_interval / effect_size.b_mean;
-
-            writeln!(
-                output_file,
-                "  {b_engine} is {ratio_min:.2}x to {ratio_max:.2}x faster than {a_engine}!",
-                a_engine = a_engine,
-                b_engine = b_engine,
-                ratio_min = ratio - ratio_ci,
-                ratio_max = ratio + ratio_ci,
-            )?;
+            if effect_size.a_mean < effect_size.b_mean {
+                let ratio = effect_size.b_mean / effect_size.a_mean;
+                let ratio_ci = effect_size.half_width_confidence_interval / effect_size.a_mean;
+                writeln!(
+                    output_file,
+                    "  {a_engine} is {ratio_min:.2}x to {ratio_max:.2}x faster than {b_engine}!",
+                    a_engine = a_engine,
+                    b_engine = b_engine,
+                    ratio_min = ratio - ratio_ci,
+                    ratio_max = ratio + ratio_ci,
+                )?;
+            } else {
+                let ratio = effect_size.a_mean / effect_size.b_mean;
+                let ratio_ci = effect_size.half_width_confidence_interval / effect_size.b_mean;
+                writeln!(
+                    output_file,
+                    "  {b_engine} is {ratio_min:.2}x to {ratio_max:.2}x faster than {a_engine}!",
+                    a_engine = a_engine,
+                    b_engine = b_engine,
+                    ratio_min = ratio - ratio_ci,
+                    ratio_max = ratio + ratio_ci,
+                )?;
+            }
         } else {
             writeln!(output_file, "  No difference in performance.")?;
         }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Sightglass Project Developers"]
 description = "Provides Rust bindings to the sightglass-next API."
 license = "Apache-2.0 WITH LLVM-exception OR MIT"
 repository = "https://github.com/bytecodealliance/sightglass"
-edition = "2018"
+edition = "2021"
 
 [dependencies]

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -3,7 +3,7 @@ name = "sightglass-build"
 version = "0.1.0"
 description = "Tools for building and describing Wasm benchmark artifacts"
 authors = ["Andrew Brown <andrew.brown@intel.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sightglass-cli"
 version = "0.1.0"
 authors = ["Sightglass Project Developers"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -518,7 +518,6 @@ compilation :: cycles :: benchmarks/pulldown-cmark/benchmark.wasm
 
   Δ = 231879938.88 ± 5920528.32 (confidence = 95%)
 
-  new_backend.so is 0.75x to 0.76x faster than old_backend.so!
   old_backend.so is 1.32x to 1.34x faster than new_backend.so!
 
   [889384088 935555419.78 1045075629] new_backend.so
@@ -528,7 +527,6 @@ compilation :: nanoseconds :: benchmarks/pulldown-cmark/benchmark.wasm
 
   Δ = 79845660.57 ± 2038688.33 (confidence = 95%)
 
-  new_backend.so is 0.75x to 0.76x faster than old_backend.so!
   old_backend.so is 1.32x to 1.34x faster than new_backend.so!
 
   [306252409 322151144.14 359863566] new_backend.so
@@ -539,7 +537,6 @@ execution :: nanoseconds :: benchmarks/pulldown-cmark/benchmark.wasm
   Δ = 467229.61 ± 57708.35 (confidence = 95%)
 
   new_backend.so is 1.13x to 1.16x faster than old_backend.so!
-  old_backend.so is 0.86x to 0.89x faster than new_backend.so!
 
   [3061587 3240065.98 4419514] new_backend.so
   [3510983 3707295.59 5811112] old_backend.so
@@ -549,7 +546,6 @@ execution :: cycles :: benchmarks/pulldown-cmark/benchmark.wasm
   Δ = 1356859.60 ± 167590.00 (confidence = 95%)
 
   new_backend.so is 1.13x to 1.16x faster than old_backend.so!
-  old_backend.so is 0.86x to 0.89x faster than new_backend.so!
 
   [8891120 9409439.69 12834660] new_backend.so
   [10196192 10766299.29 16875960] old_backend.so

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sightglass-data"
 version = "0.1.0"
 authors = ["Sightglass Project Developers"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0.40"

--- a/crates/fingerprint/Cargo.toml
+++ b/crates/fingerprint/Cargo.toml
@@ -3,7 +3,7 @@ name = "sightglass-fingerprint"
 version = "0.1.0"
 description = "Collect metadata for various parts of Sightglass"
 authors = ["Sightglass Project Developers"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/recorder/Cargo.toml
+++ b/crates/recorder/Cargo.toml
@@ -3,7 +3,7 @@ name = "sightglass-recorder"
 version = "0.1.0"
 description = "A measurement tool for compiling and running a single Wasm benchmark"
 authors = ["Sightglass Project Developers"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Instead of also showing "B is 0.73x faster than A!" which is confusing and makes the results harder to read.

Been doing some profiling recently and this has been bugging me.