### PR TITLE
Make `benchmark_effect_size` test less flaky

### DIFF
--- a/crates/cli/tests/all/benchmark.rs
+++ b/crates/cli/tests/all/benchmark.rs
@@ -146,7 +146,7 @@ fn benchmark_effect_size() -> anyhow::Result<()> {
         .arg("--processes")
         .arg("1")
         .arg("--iterations-per-process")
-        .arg("3")
+        .arg("200")
         .arg(benchmark("noop"))
         .assert()
         .success()


### PR DESCRIPTION
It complains if there isn't any variance between samples, so bump up the number
of iterations we perform to make getting all identical samples extremely
unlikely.

This flaky test seems to be holding back #194 and #193 