### PR TITLE
Ensure that at least one engine is passed in

### DIFF
--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -119,6 +119,10 @@ impl BenchmarkCommand {
             self.iterations_per_process > 0,
             "iterations-per-process must be greater than zero"
         );
+        anyhow::ensure!(
+            !self.engines.is_empty(),
+            "must pass one or more engines to benchmark with -e/--engine"
+        );
 
         if self.processes == 1 {
             self.execute_in_current_process()


### PR DESCRIPTION
Rather than silently failing to run any benchmarks.