### PR TITLE
Add additional fields to fingerprinted data

### DIFF
--- a/crates/cli/tests/all/fingerprint.rs
+++ b/crates/cli/tests/all/fingerprint.rs
@@ -39,7 +39,7 @@ fn fingerprint_benchmark() {
     let benchmark_subpath = format!("noop{}benchmark.wasm", std::path::MAIN_SEPARATOR);
     assert
         .stdout(
-            predicate::str::starts_with("name,path,hash,size\n")
+            predicate::str::starts_with("id,name,path,hash,size\n")
                 .and(predicate::str::contains(benchmark_subpath)),
         )
         .success();
@@ -70,7 +70,9 @@ fn fingerprint_engine() {
     assert
         .stdout(
             starts_with("{")
-                .and(contains(r#""name":"wasmtime-"#))
+                .and(contains(r#""id":"wasmtime-"#))
+                .and(contains(r#""name":"wasmtime""#))
+                .and(contains(r#""datetime":"20"#))
                 .and(contains(format!(r#""path":"{}""#, escaped_engine_path)))
                 .and(contains(r#""buildinfo":"NAME=wasmtime"#))
                 .and(ends_with("}")),

--- a/crates/fingerprint/src/engine.rs
+++ b/crates/fingerprint/src/engine.rs
@@ -1,6 +1,6 @@
 use crate::hash;
 use crate::util::to_string_lossy;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -11,10 +11,14 @@ const DEFAULT_NAME: &str = "custom";
 /// Describes a WebAssembly engine.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Engine {
-    /// The canonical name for the engine; e.g.:
-    /// - `wasmtime-<build info hash>` for an engine with a NAME in the build info
-    /// - `custom-<library hash>` for a pre-built engine at a given path
-    pub name: String,
+    /// A unique identifier for the engine; one of:
+    /// - `<engine name>-<build info hash>` for an engine with a NAME in the build info
+    /// - `custom-<library hash>` for a pre-built engine at a given path (no build info)
+    pub id: String,
+    /// The name of the engine, if available in the build info.
+    pub name: Option<String>,
+    /// When the engine was at this state (the commit date), if available in the build info.
+    pub datetime: Option<String>,
     /// The path to the engine.
     pub path: String,
     /// Describes the known configuration when building the engine using Sightglass.
@@ -24,20 +28,25 @@ pub struct Engine {
 impl Engine {
     /// Extract the build information of a Sightglass engine.
     pub fn fingerprint<P: AsRef<Path>>(library_path: P) -> Result<Self> {
-        let library_path = library_path.as_ref().canonicalize()?;
+        let library_path = library_path
+            .as_ref()
+            .canonicalize()
+            .context("unable to get absolute path of engine")?;
         let buildinfo_path = get_buildinfo_path_from_engine_path(&library_path)?;
         let path = to_string_lossy(&library_path);
 
         if let Ok(buildinfo_contents) = fs::read_to_string(buildinfo_path) {
-            let buildinfo_name = extract_value_from_buildinfo(&buildinfo_contents, "NAME")
-                .unwrap_or(DEFAULT_NAME.into());
-            let name = format!(
+            let name = extract_value_from_buildinfo(&buildinfo_contents, "NAME");
+            let datetime = extract_value_from_buildinfo(&buildinfo_contents, "_COMMIT_DATETIME");
+            let id = format!(
                 "{}-{}",
-                buildinfo_name,
+                name.as_ref().unwrap_or(&DEFAULT_NAME.to_string()),
                 hash::slug(&hash::string(&buildinfo_contents))
             );
             Ok(Self {
+                id,
                 name,
+                datetime,
                 path,
                 buildinfo: Some(buildinfo_contents),
             })
@@ -46,12 +55,15 @@ impl Engine {
                 "No .build-info for the engine at: {}",
                 &library_path.display()
             );
+            let id = format!(
+                "{}-{}",
+                DEFAULT_NAME,
+                hash::slug(&hash::file(&library_path))
+            );
             Ok(Self {
-                name: format!(
-                    "{}-{}",
-                    DEFAULT_NAME,
-                    hash::slug(&hash::file(&library_path))
-                ),
+                id,
+                name: None,
+                datetime: None,
                 path,
                 buildinfo: None,
             })
@@ -69,7 +81,7 @@ pub fn get_buildinfo_path_from_engine_path(engine_path: &Path) -> Result<PathBuf
 
 /// Calculate the path to a built engine's BUILD-INFO file.
 pub fn extract_value_from_buildinfo(buildinfo: &str, key: &str) -> Option<String> {
-    let re = Regex::new(&format!("(?m)^ *{} *= *([[:alnum:]]+) *", key)).unwrap();
+    let re = Regex::new(&format!("(?m)^ *{} *= *([[[:alnum:]]-_:]+) *", key)).unwrap();
     for cap in re.captures_iter(buildinfo) {
         return Some(cap[1].to_string());
     }
@@ -99,6 +111,18 @@ mod tests {
         assert_eq!(
             extract_value_from_buildinfo(buildinfo, "NAME"),
             Some("wasmtime".to_string())
+        );
+    }
+    #[test]
+    fn find_datetime_in_buildinfo() {
+        let buildinfo = r#"
+        ...
+        _COMMIT_DATETIME=2022-06-14T12:48:15-07:00
+        ...
+        "#;
+        assert_eq!(
+            extract_value_from_buildinfo(buildinfo, "_COMMIT_DATETIME"),
+            Some("2022-06-14T12:48:15-07:00".to_string())
         );
     }
 }

--- a/engines/wasmtime/README.md
+++ b/engines/wasmtime/README.md
@@ -27,8 +27,8 @@ The script can be configured in several ways:
 
 All configuration is optional. The script responds to environment variables that change the Wasmtime
 source code used; by default, the script will download the tip-of-`main` Wasmtime from the official
-repository. If provided, the first CLI argument can override the destination directory at which to
-place the built files.
+repository. Note that a `hash`, if provided, must be the full commit hash. If provided, the first
+CLI argument can override the destination directory at which to place the built files.
 
 ### Contributing
 

--- a/engines/wasmtime/build.rs
+++ b/engines/wasmtime/build.rs
@@ -4,6 +4,8 @@
 //! rustc build.rs
 //! [REPOSITORY=<repo url>] [REVISION=<hash|branch|tag>] ./build [<destination dir>]
 //! ```
+//!
+//! Note that a `hash` must be the full commit hash.
 
 #![deny(missing_docs)]
 #![deny(clippy::all)]
@@ -156,6 +158,10 @@ where
 {
     let build_dir = build_dir.as_ref();
     let commit = exec_with_stdout(&["git", "rev-parse", "HEAD"], &build_dir);
+    let datetime = exec_with_stdout(
+        &["git", "show", "--no-patch", "--no-notes", "--pretty=%cI"],
+        &build_dir,
+    );
     let cargo = exec_with_stdout(&["cargo", "--version"], &build_dir);
     let rustc = exec_with_stdout(&["rustc", "--version"], &build_dir);
     let build_info = build_dir.join(".build-info");
@@ -166,6 +172,7 @@ where
         writeln!(file, "REPOSITORY={}", repository).unwrap();
         writeln!(file, "REVISION={}", revision).unwrap();
         writeln!(file, "_COMMIT={}", commit).unwrap();
+        writeln!(file, "_COMMIT_DATETIME={}", datetime).unwrap();
         writeln!(file, "_CARGO={}", cargo).unwrap();
         writeln!(file, "_RUSTC={}", rustc).unwrap();
     }


### PR DESCRIPTION
In experimenting with uploading Sightglass data to an ElasticSearch
database, I found the following two changes to be helpful:
- adding the datetime of `HEAD` to `.build-info`: in order to sort
  engines by date, we need to record the date of the commit used to
  build the engine. This change retrieves the ISO8601 date using `git`
  and stores it in `.build-info`'s `_COMMIT_DATETIME` field.
- making the fingerprint ID consistent: this change makes the `id` field
  consistent for all of the fingerprinted data--a `<name>-<hash>` pair
  that uniquely identifies the record. This allows us to check if an
  engine record, e.g., has already been inserted for the particular
  build information it contains.