### PR TITLE
Add an `upload` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "behrens-fisher"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
+name = "bytes"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+
+[[package]]
 name = "bytesize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +169,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
+dependencies = [
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +202,16 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -355,6 +391,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +477,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+
+[[package]]
+name = "futures-io"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+
+[[package]]
+name = "futures-task"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+
+[[package]]
+name = "futures-util"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +585,25 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -499,6 +642,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa 1.0.1",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +706,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "0.14.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa 1.0.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +771,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
@@ -586,6 +817,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e21911b7183f38c71d75ab478a527f314e28db51027037ece2e5511ed9410703"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -642,6 +882,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +900,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -724,9 +1006,54 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+
+[[package]]
+name = "openssl"
+version = "0.10.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_info"
@@ -738,6 +1065,12 @@ dependencies = [
  "serde",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "perf-event"
@@ -757,6 +1090,18 @@ checksum = "ce9bedf5da2c234fdf2391ede2b90fabf585355f33100689bc364a3ea558561a"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1009,6 +1354,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,10 +1406,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1061,6 +1476,18 @@ version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
+ "itoa 1.0.1",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa 1.0.1",
  "ryu",
  "serde",
@@ -1127,6 +1554,7 @@ dependencies = [
  "sightglass-data",
  "sightglass-fingerprint",
  "sightglass-recorder",
+ "sightglass-upload",
  "structopt",
  "tempfile",
  "thiserror",
@@ -1178,6 +1606,39 @@ dependencies = [
  "sightglass-data",
  "thiserror",
  "wat",
+]
+
+[[package]]
+name = "sightglass-upload"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "log",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sightglass-data",
+ "sightglass-fingerprint",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1321,10 +1782,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "socket2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1343,6 +1918,24 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -1366,6 +1959,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,9 +1988,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -1395,13 +1998,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1409,10 +2012,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.80"
+name = "wasm-bindgen-futures"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1420,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1433,9 +2048,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "wasmparser"
@@ -1474,6 +2089,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0401b6395ce0db91629a75b29597ccb66ea29950af9fc859f1bb3a736609c76e"
 dependencies = [
  "wast",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1518,6 +2143,58 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "xattr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ members = [
     "crates/cli",
     "crates/data",
     "crates/fingerprint",
-    "crates/recorder"
+    "crates/recorder",
+    "crates/upload",
 ]
 default-members = [
     "crates/cli"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ sightglass-build = { path = "../build" }
 sightglass-data = { path = "../data" }
 sightglass-fingerprint = { path = "../fingerprint" }
 sightglass-recorder = { path = "../recorder" }
+sightglass-upload = { path = "../upload" }
 structopt = { version = "0.3", features = ["color", "suggestions"] }
 thiserror = "1.0"
 rand = { version = "0.7.3", features = ["small_rng"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -37,7 +37,7 @@ enum SightglassCommand {
     EffectSize(EffectSizeCommand),
     Fingerprint(FingerprintCommand),
     Summarize(SummarizeCommand),
-    Upload(UploadCommand),
+    UploadElastic(UploadCommand),
     Validate(ValidateCommand),
 }
 
@@ -49,7 +49,7 @@ impl SightglassCommand {
             SightglassCommand::EffectSize(effect_size) => effect_size.execute(),
             SightglassCommand::Fingerprint(fingerprint) => fingerprint.execute(),
             SightglassCommand::Summarize(summarize) => summarize.execute(),
-            SightglassCommand::Upload(upload) => upload.execute(),
+            SightglassCommand::UploadElastic(upload) => upload.execute(),
             SightglassCommand::Validate(validate) => validate.execute(),
         }
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,7 @@ mod benchmark;
 mod effect_size;
 mod fingerprint;
 mod summarize;
+mod upload;
 mod validate;
 
 use anyhow::Result;
@@ -11,6 +12,7 @@ use fingerprint::FingerprintCommand;
 use log::trace;
 use structopt::{clap::AppSettings, StructOpt};
 use summarize::SummarizeCommand;
+use upload::UploadCommand;
 use validate::ValidateCommand;
 
 /// Main entry point for CLI.
@@ -32,10 +34,11 @@ fn main() -> Result<()> {
 )]
 enum SightglassCommand {
     Benchmark(BenchmarkCommand),
-    Validate(ValidateCommand),
-    Summarize(SummarizeCommand),
     EffectSize(EffectSizeCommand),
     Fingerprint(FingerprintCommand),
+    Summarize(SummarizeCommand),
+    Upload(UploadCommand),
+    Validate(ValidateCommand),
 }
 
 impl SightglassCommand {
@@ -43,10 +46,11 @@ impl SightglassCommand {
         trace!("Executing command: {:?}", &self);
         match self {
             SightglassCommand::Benchmark(benchmark) => benchmark.execute(),
-            SightglassCommand::Validate(validate) => validate.execute(),
-            SightglassCommand::Summarize(summarize) => summarize.execute(),
             SightglassCommand::EffectSize(effect_size) => effect_size.execute(),
             SightglassCommand::Fingerprint(fingerprint) => fingerprint.execute(),
+            SightglassCommand::Summarize(summarize) => summarize.execute(),
+            SightglassCommand::Upload(upload) => upload.execute(),
+            SightglassCommand::Validate(validate) => validate.execute(),
         }
     }
 }

--- a/crates/cli/src/upload.rs
+++ b/crates/cli/src/upload.rs
@@ -1,0 +1,68 @@
+use anyhow::{Context, Result};
+use sightglass_data::{Format, Measurement};
+use sightglass_upload::{upload, upload_package, MeasurementPackage};
+use std::{
+    fs::File,
+    io::{self, BufReader, Read},
+};
+use structopt::StructOpt;
+
+/// Upload benchmark output to server; accepts raw benchmark results in `stdin` (i.e., from
+/// `sightglass-cli benchmark ...`).
+#[derive(Debug, StructOpt)]
+#[structopt(name = "upload")]
+pub struct UploadCommand {
+    /// The format of the input data. Either 'json' or 'csv'.
+    #[structopt(short = "i", long = "input-format", default_value = "json")]
+    input_format: Format,
+
+    /// Path to the file that will be read from, or none to indicate stdin
+    /// (default).
+    #[structopt(short = "f", long = "input-file")]
+    input_file: Option<String>,
+
+    /// The URL of a server receiving results; this command only understands how
+    /// to upload results to an ElasticSearch server; e.g.,
+    /// `http://localhost:9200`.
+    #[structopt(index = 1, default_value = "http://localhost:9200", value_name = "URL")]
+    server: String,
+
+    /// Setting this flag will prevent any uploading to the server. Instead,
+    /// the command will emit a JSON "package" to stdout that can be used to
+    /// upload at a later time, see `--from-package`.
+    #[structopt(short = "d", long = "dry-run")]
+    dry_run: bool,
+
+    /// Path to a file containing a package of measurements and fingerprint data
+    /// to be uploaded. If this is set, `--input-file` and `--input-format` are
+    /// ignored.
+    #[structopt(short = "p", long = "from-package")]
+    from_package: Option<String>,
+
+    /// The number of measurements to upload together; this can speed up the
+    /// upload. Defaults to `2000`.
+    #[structopt(short = "b", long = "batch-size", default_value = "2000")]
+    batch_size: usize,
+}
+
+impl UploadCommand {
+    pub fn execute(&self) -> Result<()> {
+        if let Some(file) = &self.from_package {
+            let reader =
+                BufReader::new(File::open(file).context("unable to open --from-package path")?);
+            let package: MeasurementPackage =
+                serde_json::from_reader(reader).context("unable to parse --from-package JSON")?;
+            upload_package(&self.server, self.batch_size, self.dry_run, package)
+        } else {
+            let file: Box<dyn Read> = if let Some(file) = self.input_file.as_ref() {
+                Box::new(BufReader::new(
+                    File::open(file).context("unable to open --input-file")?,
+                ))
+            } else {
+                Box::new(io::stdin())
+            };
+            let measurements: Vec<Measurement> = self.input_format.read(file)?;
+            upload(&self.server, self.batch_size, self.dry_run, measurements)
+        }
+    }
+}

--- a/crates/cli/src/upload.rs
+++ b/crates/cli/src/upload.rs
@@ -7,10 +7,10 @@ use std::{
 };
 use structopt::StructOpt;
 
-/// Upload benchmark output to server; accepts raw benchmark results in `stdin` (i.e., from
-/// `sightglass-cli benchmark ...`).
+/// Upload benchmark output to an ElasticSearch server; accepts raw benchmark
+/// results in `stdin` (i.e., from `sightglass-cli benchmark ...`).
 #[derive(Debug, StructOpt)]
-#[structopt(name = "upload")]
+#[structopt(name = "upload-elastic")]
 pub struct UploadCommand {
     /// The format of the input data. Either 'json' or 'csv'.
     #[structopt(short = "i", long = "input-format", default_value = "json")]

--- a/crates/cli/tests/all/main.rs
+++ b/crates/cli/tests/all/main.rs
@@ -1,6 +1,7 @@
 mod benchmark;
 mod fingerprint;
 mod help;
+mod upload;
 mod util;
 
 fn main() {}

--- a/crates/cli/tests/all/upload.rs
+++ b/crates/cli/tests/all/upload.rs
@@ -11,7 +11,7 @@ use predicates::prelude::*;
 #[test]
 fn upload_dryrun() {
     let assert = sightglass_cli()
-        .arg("upload")
+        .arg("upload-elastic")
         .arg("--dry-run")
         .arg("--input-file")
         .arg("tests/results.json")

--- a/crates/cli/tests/all/upload.rs
+++ b/crates/cli/tests/all/upload.rs
@@ -1,0 +1,52 @@
+//! Test `sightglass-cli upload`.
+
+use super::util::{benchmark, sightglass_cli, test_engine};
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+
+#[test]
+fn upload_dryrun() {
+    let assert = sightglass_cli()
+        .arg("upload")
+        .arg("--dry-run")
+        .arg("--input-file")
+        .arg("tests/results.json")
+        .arg("--batch-size")
+        .arg("200")
+        .env("RUST_LOG", "debug")
+        .assert();
+
+    // Gather up the logged output from stderr.
+    let stderr = std::str::from_utf8(&assert.get_output().stderr).unwrap();
+    eprintln!("=== stderr ===\n{}\n===========", stderr);
+
+    // Gather the fingerprints of the system under test.
+    let engine = sightglass_fingerprint::Engine::fingerprint(test_engine()).unwrap();
+    let benchmark = sightglass_fingerprint::Benchmark::fingerprint(benchmark("noop")).unwrap();
+    let machine = sightglass_fingerprint::Machine::fingerprint().unwrap();
+
+    // Check that we upload measurement records for each of the measurements in the file.
+    let num_uploaded_batches = stderr
+        .matches("Batching up 200 records to index 'measurements'")
+        .count();
+    assert_eq!(num_uploaded_batches, 3);
+
+    // Also, heck that we create records for the engine/machine/benchmark.
+    use predicate::str::*;
+    assert
+        .stderr(
+            contains(format!(
+                r#"Creating record in 'engines' with ID Some("{}")"#,
+                engine.id
+            ))
+            .and(contains(format!(
+                r#"Creating record in 'machines' with ID Some("{}")"#,
+                machine.id
+            )))
+            .and(contains(format!(
+                r#"Creating record in 'benchmarks' with ID Some("{}")"#,
+                benchmark.id
+            ))),
+        )
+        .success();
+}

--- a/crates/cli/tests/all/upload.rs
+++ b/crates/cli/tests/all/upload.rs
@@ -4,6 +4,10 @@ use super::util::{benchmark, sightglass_cli, test_engine};
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
 
+// Because the `results.json` contains `*.so` suffixes for the engine, this test
+// can only run where the fingerprinted engine will have a matching suffix,
+// i.e., Linux.
+#[cfg(target_os = "linux")]
 #[test]
 fn upload_dryrun() {
     let assert = sightglass_cli()

--- a/crates/cli/tests/results.json
+++ b/crates/cli/tests/results.json
@@ -1,0 +1,6002 @@
+[
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 289553592
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 90846073
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 281951
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 88460
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1529
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 479
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 60544846
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 18995659
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 159403
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 50011
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1569
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 492
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 61026648
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 19146822
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 130059
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 40805
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 757
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 237
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 57999989
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 18197223
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 113872
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 35726
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 726
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 227
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 58387422
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 18318778
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 192849
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 60505
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1537
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 482
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 53730141
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 16857578
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 96885
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 30397
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 567
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 177
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 41635593
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 13062970
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 69070
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 21670
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 459
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 144
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 32966762
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10343166
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 64797
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 20329
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 478
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 149
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 34254592
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10747216
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 59478
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 18660
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 421
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 132
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 33378232
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10472262
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 125945
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 39514
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 996
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 654988,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 312
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 302671029
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 94962142
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 304930
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 95670
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1443
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 452
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 61562013
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 19314900
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 163312
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 51238
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1041
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 326
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 57697845
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 18102528
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 119287
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 37425
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 751
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 235
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 57662154
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 18091330
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 94458
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 29635
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 643
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 201
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 46847712
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 14698331
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 80401
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 25225
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 670
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 210
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 44099560
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 13836106
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 62974
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 19757
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 476
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 149
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 36929004
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 11586366
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 64094
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 20109
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 476
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 149
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 35126264
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 11020761
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 67305
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 21116
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 460
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 144
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 34698239
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10886470
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 62677
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 19664
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 387
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 121
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 30675777
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 9624434
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 63801
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 20017
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 405
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655073,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 127
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 324276230
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 101740224
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 312187
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 97947
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1779
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 558
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 62665010
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 19660868
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 268019
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 84089
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 2747
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 861
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 60576052
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 19005466
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 150119
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 47099
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 923
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 289
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 57124017
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 17922406
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 95185
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 29863
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 634
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 198
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 53465329
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 16774509
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 86792
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 27230
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 538
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 168
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 46494167
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 14587338
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 77624
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 24354
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 561
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 176
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 39440792
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 12374373
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 63928
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 20057
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 419
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 131
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 35489557
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 11134690
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 139942
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 43906
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 447
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 140
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 26960279
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 8458667
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 63454
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 19908
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 390
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 122
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 25686567
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 8059046
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 62523
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 19616
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 433
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655110,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 135
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 265213417
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 83209278
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 308704
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 96854
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 2660
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 834
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 65399105
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 20518616
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 233341
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 73209
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1245
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 390
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 62995020
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 19764347
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 149632
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 46946
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1022
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 320
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 60119455
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 18862154
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 99987
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 31370
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 753
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 236
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 59217825
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 18579273
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 101809
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 31942
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 627
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 196
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 49947975
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 15670907
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 69612
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 21840
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 413
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 129
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 43859599
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 13760712
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 68515
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 21496
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 610
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 191
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 31793950
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 9975180
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 64418
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 20210
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 415
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 130
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 37214633
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 11675890
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 63941
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 20061
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 386
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 121
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 35565756
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 11158564
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 139471
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 43758
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 358
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655141,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 112
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 262185111
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 82259284
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 310724
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 97488
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1553
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 487
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 65051260
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 20409511
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 201169
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 63115
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1143
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 358
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 61336253
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 19243946
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 98054
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 30763
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 773
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 242
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 48481755
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 15210911
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 59622
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 18706
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 382
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 119
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 31733293
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 9956164
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 64183
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 20137
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 385
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 120
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 31917851
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10014068
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 59920
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 18799
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 364
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 114
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 27813652
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 8726396
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 141391
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 44360
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 413
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 129
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 28863128
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 9055663
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 66625
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 20903
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 409
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 128
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 29099705
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 9129888
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 75263
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 23613
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 432
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 135
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 27745664
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 8705065
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 64028
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 20088
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 326
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655177,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 102
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 286073413
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 89754065
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 312290
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 97979
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1915
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 600
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 61466464
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 19284787
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 150823
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 47319
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1243
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 389
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 62689408
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 19668480
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 103841
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 32579
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 950
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 298
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 47535883
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 14914139
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 61837
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 19401
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 417
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 130
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 29720051
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 9324513
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 61451
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 19279
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 413
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 129
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 31902476
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10009238
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 155240
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 48705
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1460
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 458
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 38397676
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 12047073
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 165931
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 52059
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1635
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 512
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 53779620
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 16873079
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 74783
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 23462
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 547
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 171
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 43858847
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 13760488
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 74220
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 23286
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 560
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 175
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 39186515
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 12294567
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 62566
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 19629
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 390
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655215,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 122
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 289420510
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 90804385
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 359647
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 112837
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 2253
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 706
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 59503356
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 18668910
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 143072
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 44888
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 921
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 288
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 58006862
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 18199392
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 139366
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 43725
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 899
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 282
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 58727776
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 18425576
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 88387
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 27731
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 573
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 179
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 44825990
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 14063953
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 71336
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 22381
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 596
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 186
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 34595018
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10854031
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 58685
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 18412
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 459
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 144
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 32919588
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10328372
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 59274
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 18596
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 502
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 157
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 32148853
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10086558
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 60732
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 19054
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 427
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 133
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 30696509
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 9630891
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 111906
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 35110
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 868
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 272
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 33244128
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10430195
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 62639
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 19652
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 413
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655246,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 129
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 314472858
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 98664344
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 284874
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 89377
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1644
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 515
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 61963990
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 19440903
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 178873
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 56120
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1075
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 337
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 60965960
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 19127776
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 125079
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 39242
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 905
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 283
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 55091849
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 17284802
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 86914
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 27268
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 566
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 177
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 51850762
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 16267926
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 85202
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 26731
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 342
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 107
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 32560549
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10215715
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 68823
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 21592
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 440
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 138
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 34810636
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10921669
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 177193
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 55593
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1142
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 358
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 37612748
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 11800818
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 69036
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 21659
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 381
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 119
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 32033107
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10050233
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 62785
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 19698
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 599
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 187
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 29085350
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 9125388
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 139059
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 43629
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 394
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655277,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 123
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 85911558
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 26954941
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 339519
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 106524
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 2468
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 774
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 33412492
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10483243
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 307922
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 96611
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 2370
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 743
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 35047922
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 10996362
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 196746
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 61729
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1774
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 556
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 28359328
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 8897801
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 74386
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 23338
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1019
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 319
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 31432933
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 9862152
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 155856
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 48900
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1524
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 478
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 31276604
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 9813103
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 61246
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 19216
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 504
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 158
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 38579616
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 12104439
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 123518
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 38754
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 978
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 306
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 29106160
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 9132121
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 59912
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 18797
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 457
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 143
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 23613218
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 7408699
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 93262
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 29261
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 735
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 230
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 21348802
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 6698233
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 97978
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 30740
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 715
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655308,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 224
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 290898141
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 0,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 91267438
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 399775
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 0,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 125426
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 2665
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 0,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 836
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 63007476
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 1,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 19768194
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 168809
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 1,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 52962
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 1201
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 1,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 376
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 56022364
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 2,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 17576659
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 71983
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 2,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 22584
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 453
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 2,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 142
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 38022776
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 3,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 11929403
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 58720
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 3,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 18423
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 393
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 3,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 123
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 41351793
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 4,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 12973861
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 60817
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 4,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 19080
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 436
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 4,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 136
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 39588733
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 5,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 12420712
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 69139
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 5,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 21691
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 551
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 5,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 172
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 39432539
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 6,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 12371707
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 59102
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 6,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 18542
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 476
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 6,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 149
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 37277300
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 7,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 11695515
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 59446
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 7,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 18650
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 522
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 7,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 163
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 38383391
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 8,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 12042544
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 59167
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 8,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 18563
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 437
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 8,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 137
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "cycles",
+        "count": 31762826
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 9,
+        "phase": "Compilation",
+        "event": "nanoseconds",
+        "count": 9965384
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "cycles",
+        "count": 58772
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 9,
+        "phase": "Instantiation",
+        "event": "nanoseconds",
+        "count": 18439
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "cycles",
+        "count": 410
+    },
+    {
+        "arch": "x86_64",
+        "engine": "../../engines/wasmtime/libengine.so",
+        "wasm": "../../benchmarks/noop/benchmark.wasm",
+        "process": 655341,
+        "iteration": 9,
+        "phase": "Execution",
+        "event": "nanoseconds",
+        "count": 128
+    }
+]

--- a/crates/upload/Cargo.toml
+++ b/crates/upload/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sightglass-upload"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0"
+chrono = "0.4"
+log = "0.4"
+reqwest = { version = "0.11", features = ["blocking"] }
+serde = { version = "1.0.118", features = ["derive", "rc"] }
+serde_json = "1.0.60"
+sightglass-data = { path = "../data" }
+sightglass-fingerprint = { path = "../fingerprint" }

--- a/crates/upload/src/database.rs
+++ b/crates/upload/src/database.rs
@@ -1,0 +1,174 @@
+use anyhow::{anyhow, bail, Result};
+use reqwest::blocking::Client;
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// A simple HTTP wrapper for communicating with an ElasticSearch database.
+pub struct Database {
+    url: String,
+    dry_run: bool,
+}
+
+impl Database {
+    pub fn new(url: String, dry_run: bool) -> Self {
+        Self {
+            url: url.trim_end_matches("/").to_string(),
+            dry_run,
+        }
+    }
+
+    /// Use the ElasticSearch [Get
+    /// API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html)
+    /// to verify if a document exists in `index` with the given `id`.
+    #[allow(dead_code)]
+    pub fn exists(&self, index: &str, id: &str) -> Result<bool> {
+        let url = format!("{}/{}/_doc/{}", self.url, index, id);
+        if self.dry_run {
+            Ok(true)
+        } else {
+            let client = Client::new();
+            let response = client.head(url).send()?;
+            Ok(response.status().is_success())
+        }
+    }
+
+    /// Retrieve an object from the database, if it exists.
+    pub fn get<'a, T>(&self, index: &str, id: &str) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        let url = format!("{}/{}/_doc/{}", self.url, index, id);
+        if self.dry_run {
+            bail!("could not retrieve object with ID: {}", id);
+        } else {
+            let client = Client::new();
+            let response = client.get(url).send()?;
+            let bytes = response.bytes()?;
+            Ok(serde_json::from_slice(bytes.as_ref())?)
+        }
+    }
+
+    /// Create an object in the database, reusing an existing object if
+    /// possible. This function handles several cases:
+    ///  1. if the ID is not used in the database, create the object
+    ///  2. if the ID is used and the existing object matches `object`, simply
+    ///     return the ID without creating a new database entry
+    ///  3. if the ID is used and the existing object does not match `object`,
+    ///     append a `!` to the ID and retry (up to 5 times).
+    pub fn create_if_not_exists<'a, T>(&self, index: &str, object: &T, id: &str) -> Result<String>
+    where
+        T: DeserializeOwned + Serialize + PartialEq,
+    {
+        let mut id = id.to_string();
+        for _ in 0..NUM_RETRIES {
+            match self.get(index, &id) {
+                Ok(stored_object) => {
+                    if object == &stored_object {
+                        // Case #2: the same object already exists in the
+                        // database; simply return the ID.
+                        return Ok(id);
+                    } else {
+                        // Case #3: a different object exists with the same ID;
+                        // change the ID and retry.
+                        id.push('!');
+                    }
+                }
+                Err(_) => {
+                    // Case #1: no object exists with the ID; create it.
+                    return self.create(index, object, Some(&id));
+                }
+            }
+        }
+        Err(anyhow!("failed to find a usable ID"))
+    }
+
+    /// Use the ElasticSearch [Index
+    /// API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html)
+    /// to add a document to `index`, optionally with the given `id`.
+    pub fn create<T>(&self, index: &str, object: &T, id: Option<&str>) -> Result<String>
+    where
+        T: Serialize,
+    {
+        log::debug!("Creating record in '{}' with ID {:?}", index, id);
+        let url = if let Some(id) = id {
+            format!("{}/{}/_doc/{}", self.url, index, id)
+        } else {
+            format!("{}/{}/_doc", self.url, index)
+        };
+
+        let body = serde_json::to_string(object)?;
+        log::trace!("Record body: {}", &body);
+
+        if self.dry_run {
+            Ok(if let Some(id) = id {
+                id.to_string()
+            } else {
+                "dry-run-id".to_string()
+            })
+        } else {
+            let client = Client::new();
+            let response = client
+                .post(url)
+                .header("Content-Type", "application/json")
+                .body(body)
+                .send()?;
+
+            let success = response.status().is_success();
+            let content: HashMap<String, Value> = serde_json::from_slice(&response.bytes()?)?;
+            log::debug!("ElasticSearch response: {:?}", content);
+
+            if success {
+                let id = content.get("_id").unwrap().as_str().unwrap().to_string();
+                Ok(id)
+            } else {
+                bail!("Failed to create record: {:?}", content)
+            }
+        }
+    }
+
+    /// Use the ElasticSearch [Bulk
+    /// API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html)
+    /// to add many objects to `index`. This should be significantly faster than
+    /// `create`.
+    pub fn create_batched<T>(&self, index: &str, objects: &[T]) -> Result<()>
+    where
+        T: Serialize,
+    {
+        log::debug!("Batching up {} records to index '{}'", objects.len(), index);
+        let url = format!("{}/{}/_bulk", self.url, index);
+
+        // Capture all of the records as index requests.
+        let mut body = vec![];
+        for o in objects {
+            body.push("{\"index\": {}}\n".to_string());
+            body.push(format!("{}\n", serde_json::to_string(o)?));
+        }
+        let body = body.concat();
+
+        // Upload the entire batch request to ElasticSearch.
+        if self.dry_run {
+            log::trace!("Record body: {}", &body);
+            Ok(())
+        } else {
+            let client = Client::new();
+            let response = client
+                .post(url)
+                .header("Content-Type", "application/x-ndjson")
+                .body(body)
+                .send()?;
+
+            let success = response.status().is_success();
+            let content: HashMap<String, Value> = serde_json::from_slice(&response.bytes()?)?;
+            log::debug!("ElasticSearch response: {:?}", content);
+
+            if success {
+                Ok(())
+            } else {
+                bail!("Failed to batch-create records: {:?}", content)
+            }
+        }
+    }
+}
+
+const NUM_RETRIES: i32 = 5;

--- a/crates/upload/src/lib.rs
+++ b/crates/upload/src/lib.rs
@@ -1,0 +1,141 @@
+//! Upload Sightglass data into an ElasticSearch database.
+mod database;
+mod measurement;
+
+use crate::database::Database;
+use crate::measurement::UploadMeasurement;
+use anyhow::{Context, Result};
+pub use measurement::MeasurementPackage;
+use sightglass_data::Measurement;
+use sightglass_fingerprint::{Benchmark, Engine, Machine};
+use std::collections::{HashMap, HashSet};
+use std::io;
+
+/// Upload `measurements` to the `server`.
+///
+/// Uploading to a database will replace several fields of the raw [Measurement]
+/// with fingerprinted data from the current server; this adds useful metadata
+/// to the results. E.g., the `arch` field in [Measurement] is expanded to the
+/// more-complete [Machine] fingerprint.
+pub fn upload(
+    server: &str,
+    batch_size: usize,
+    dry_run: bool,
+    measurements: Vec<Measurement>,
+) -> Result<()> {
+    let package = package(measurements)?;
+
+    if dry_run {
+        serde_json::to_writer(io::stdout(), &package)
+            .context("failed to write measurement package to stdout")?;
+    }
+
+    upload_package(server, batch_size, dry_run, package)
+}
+
+/// Package up the [Measurement]s alongside the fingerprint data from the
+/// current system.
+///
+/// The concept of "packaging up" the data allows for saving the entire
+/// data collection for later upload in environments where access to the
+/// database is impossible.
+pub fn package(measurements: Vec<Measurement>) -> Result<MeasurementPackage> {
+    // De-duplicate all of the engines and benchmarks used in this result set.
+    let mut found_engines = HashSet::new();
+    let mut found_benchmarks = HashSet::new();
+    for m in measurements.iter() {
+        found_engines.insert(m.engine.clone());
+        found_benchmarks.insert(m.wasm.clone());
+    }
+
+    // Map each engine path to its fingerprinted data.
+    let mut engines = HashMap::new();
+    for engine_path in found_engines.into_iter() {
+        let engine = Engine::fingerprint(engine_path.as_ref())?;
+        engines.insert(engine_path, engine);
+    }
+
+    // Map each benchmark path to its fingerprinted data.
+    let mut benchmarks = HashMap::new();
+    for benchmark_path in found_benchmarks.into_iter() {
+        let benchmark = Benchmark::fingerprint(benchmark_path.as_ref())?;
+        benchmarks.insert(benchmark_path, benchmark);
+    }
+
+    // Fingerprint the current machine.
+    let machine = Machine::fingerprint()?;
+
+    // Capture the current time.
+    let datetime = chrono::Local::now().to_rfc3339().into();
+
+    Ok(MeasurementPackage {
+        measurements,
+        engines,
+        benchmarks,
+        machine,
+        datetime,
+    })
+}
+
+/// Upload the packaged measurements and fingerprint data to the database.
+///
+/// This adds records to the database for each kind of record in the package
+/// (measurements, machine, engines, benchmarks), avoiding new records for
+/// fingerprinted data that is already present in the database (e.g., we do not
+/// want multiple records for the same machine). If `dry_run` is set no records
+/// are actually inserted, only logged.
+///
+/// As described in the [tuning documentation], the optimal ElasticSearch
+/// `batch_size` must be determined through experimentation. In a small
+/// experiment, increasing the batch size saw diminishing returns after
+/// `1000-2000`.
+///
+/// [tuning documentation]:
+///     https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html#_use_bulk_requests
+pub fn upload_package(
+    server: &str,
+    batch_size: usize,
+    dry_run: bool,
+    package: MeasurementPackage,
+) -> Result<()> {
+    let database = Database::new(server.to_string(), dry_run);
+
+    // Insert each fingerprinted version of an engine.
+    let mut engines = HashMap::new();
+    for (path, fingerprint) in package.engines.into_iter() {
+        let id = database.create_if_not_exists("engines", &fingerprint, &fingerprint.id)?;
+        log::debug!("Mapping engine: {} -> {}", &path, &id);
+        engines.insert(path, id);
+    }
+
+    // Insert each fingerprinted version of a benchmark.
+    let mut benchmarks = HashMap::new();
+    for (path, fingerprint) in package.benchmarks.into_iter() {
+        let id = database.create_if_not_exists("benchmarks", &fingerprint, &fingerprint.id)?;
+        log::debug!("Mapping benchmark: {} -> {}", &path, &id);
+        benchmarks.insert(path, id);
+    }
+
+    // Insert the machine fingerprint.
+    let machine =
+        database.create_if_not_exists("machines", &package.machine, &package.machine.id)?;
+
+    // Insert all of the measurements.
+    for batch in package.measurements.chunks(batch_size) {
+        let batch = batch
+            .into_iter()
+            .map(|m| {
+                UploadMeasurement::map_and_convert(
+                    &machine,
+                    &engines,
+                    &benchmarks,
+                    &package.datetime,
+                    m,
+                )
+            })
+            .collect::<Vec<_>>();
+        database.create_batched("measurements", &batch)?;
+    }
+
+    Ok(())
+}

--- a/crates/upload/src/measurement.rs
+++ b/crates/upload/src/measurement.rs
@@ -1,0 +1,99 @@
+//! Provides [UploadMeasurement], a data type to convert to before uploading
+//! Sightglass [Measurement] objects to a server.
+use serde::{Deserialize, Serialize};
+use sightglass_data::{Measurement, Phase};
+use sightglass_fingerprint::{Benchmark, Engine, Machine};
+use std::{borrow::Cow, collections::HashMap};
+
+/// A conversion of a [Measurement], with fields replaced by fingerprinting.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UploadMeasurement<'a> {
+    /// The ID of the machine on which this measurement was taken; this relies
+    /// on `upload` to insert the data for this ID.
+    pub machine: Cow<'a, str>,
+
+    /// The ID of the engine in which this measurement was taken; this relies on
+    /// `upload` to insert the data for this ID.
+    pub engine: Cow<'a, str>,
+
+    /// The ID of the benchmark with which this measurement was taken; this
+    /// relies on `upload` to insert the data for this ID.
+    pub benchmark: Cow<'a, str>,
+
+    /// The id of the process within which this measurement was taken.
+    pub process: u32,
+
+    /// This measurement was the `n`th measurement of this phase taken within a
+    /// process.
+    pub iteration: u32,
+
+    /// The phase in a Wasm program's lifecycle that was measured: compilation,
+    /// instantiation, or execution.
+    pub phase: Phase,
+
+    /// The event that was measured: micro seconds of wall time, CPU cycles
+    /// executed, instructions retired, cache misses, etc.
+    pub event: Cow<'a, str>,
+
+    /// The event counts.
+    ///
+    /// The meaning and units depend on what the `event` is: it might be a count
+    /// of microseconds if the event is wall time, or it might be a count of
+    /// instructions if the event is instructions retired.
+    pub count: u64,
+
+    /// When the measurement was collected into a package (not necessarily when
+    /// it was measured).
+    pub datetime: Cow<'a, str>,
+}
+
+impl<'a> UploadMeasurement<'a> {
+    pub fn convert(
+        machine: &'a str,
+        engine: &'a str,
+        benchmark: &'a str,
+        datetime: &'a str,
+        measurement: &'a Measurement,
+    ) -> Self {
+        Self {
+            machine: Cow::Borrowed(machine),
+            engine: Cow::Borrowed(engine),
+            benchmark: Cow::Borrowed(benchmark),
+            process: measurement.process,
+            iteration: measurement.iteration,
+            phase: measurement.phase,
+            event: Cow::Borrowed(measurement.event.as_ref()),
+            count: measurement.count,
+            datetime: Cow::Borrowed(datetime),
+        }
+    }
+
+    pub fn map_and_convert(
+        machine: &'a str,
+        engines: &'a HashMap<Cow<'_, str>, String>,
+        benchmarks: &'a HashMap<Cow<'_, str>, String>,
+        datetime: &'a str,
+        measurement: &'a Measurement,
+    ) -> Self {
+        let engine = engines.get(measurement.engine.as_ref()).unwrap().as_ref();
+        let benchmark = benchmarks.get(measurement.wasm.as_ref()).unwrap().as_ref();
+        Self::convert(&machine, engine, benchmark, datetime, measurement)
+    }
+}
+
+/// This container captures all of the measurement data from a single machine in
+/// a format that can be exported and later uploaded.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MeasurementPackage<'a> {
+    /// Store all the original measurements for upload.
+    pub measurements: Vec<Measurement<'a>>,
+    /// Map each engine path to its fingerprinted data.
+    pub engines: HashMap<Cow<'a, str>, Engine>,
+    /// Map each benchmark path to its fingerprinted data.
+    pub benchmarks: HashMap<Cow<'a, str>, Benchmark>,
+    /// Collect the machine fingerprint.
+    pub machine: Machine,
+    /// When the measurements were collected into a package (not necessarily
+    /// when they were measured).
+    pub datetime: Cow<'a, str>,
+}


### PR DESCRIPTION
This change adds the ability to upload some Sightglass measurement data
to an ElasticSearch server. To do so, the parts of the data that are
environment-specific (machine, engine, benchmark) are "fingerprinted,"
or given a unique ID to differentiate them from other data points. The
"fingerprinting" also serves to unify data points more safely. E.g., if
the same benchmark is run on two different machines with the same
engine, the database will contain two machine entries and a single entry
each for the engine and benchmark; the measurement entries will
reference the de-duplicated ID.

For example, to upload some measurements to the (default) localhost server:

```console
$ sightglass-cli upload -f measurements.json
```

The mechanism for uploading the various data points to an HTTP endpoint
is specific to ElasticSearch in expectation of a future commit defining
how to run such a database. With some work, this `upload` functionality
could be made more generic or adapted to other database types.

This commit also contains the ability to upload measurement data at a
later time. This is helpful if the ElasticSearch endpoint is not
available from wherever the measurements are collected. In this scenario
(which I have often been in), the fingerprinted, timestamped
measurements can be "packaged up" into a JSON file using the `--dry-run`
flag and moved to where they can subsequently be uploaded. For example:

```console
$ sightglass-cli upload --dry-run -f measurements.json > package.json
[move package.json to some other place]
$ sightglass-cli upload --from-package package.json
```