### PR TITLE
Add a new measure for just instructions retired

### DIFF
--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -78,7 +78,7 @@ pub struct BenchmarkCommand {
     #[structopt(short = "o", long = "output-file")]
     output_file: Option<String>,
 
-    /// The type of measurement to use (cycles, perf-counters, noop, vtune)
+    /// The type of measurement to use (cycles, insts-retired, perf-counters, noop, vtune)
     /// when recording the benchmark performance.
     #[structopt(long, short, default_value = "cycles")]
     measure: MeasureType,

--- a/crates/recorder/src/measure/counters.rs
+++ b/crates/recorder/src/measure/counters.rs
@@ -30,7 +30,8 @@ impl CounterMeasure {
                 .build()
                 .expect(
                     "Unable to create CPU_CYCLES hardware counter. Does this system actually \
-                have such a counter? If it does, your kernel may not fully support this processor.",
+                     have such a counter? If it does, your kernel may not fully support this \
+                     processor.",
                 ),
             instructions_retired: Builder::new()
                 .group(&mut group)
@@ -39,7 +40,7 @@ impl CounterMeasure {
                 .expect(
                     "Unable to create INSTRUCTIONS hardware counter. Does this system actually \
                     have such a counter? If it does, your kernel may not fully support this \
-                processor.",
+                    processor.",
                 ),
             cache_accesses: Builder::new()
                 .group(&mut group)
@@ -47,7 +48,8 @@ impl CounterMeasure {
                 .build()
                 .expect(
                     "Unable to create CACHE_REFERENCES hardware counter. Does this system actually \
-                have such a counter? If it does, your kernel may not fully support this processor.",
+                     have such a counter? If it does, your kernel may not fully support this \
+                     processor.",
                 ),
             cache_misses: Builder::new()
                 .group(&mut group)
@@ -55,7 +57,8 @@ impl CounterMeasure {
                 .build()
                 .expect(
                     "Unable to create CACHE_MISSES hardware counter. Does this system actually \
-                have such a counter? If it does, your kernel may not fully support this processor.",
+                     have such a counter? If it does, your kernel may not fully support this \
+                     processor.",
                 ),
             event_group: group,
         }

--- a/crates/recorder/src/measure/insts.rs
+++ b/crates/recorder/src/measure/insts.rs
@@ -1,0 +1,62 @@
+//! Measure instructions retired via perf events.
+
+use super::Measure;
+use crate::measure::Measurements;
+use perf_event::{events::Hardware, Builder, Counter};
+use sightglass_data::Phase;
+
+/// Measure CPU counters.
+pub struct InstsRetiredMeasure(Counter);
+
+impl InstsRetiredMeasure {
+    pub fn new() -> Self {
+        let counter = Builder::new().kind(Hardware::INSTRUCTIONS).build().expect(
+            "Unable to create INSTRUCTIONS hardware counter. Does this system actually \
+             have such a counter? If it does, your kernel may not fully support this \
+             processor.",
+        );
+        InstsRetiredMeasure(counter)
+    }
+}
+
+impl Measure for InstsRetiredMeasure {
+    fn start(&mut self, _phase: Phase) {
+        self.0.reset().unwrap();
+        self.0.enable().unwrap()
+    }
+
+    fn end(&mut self, phase: Phase, measurements: &mut Measurements) {
+        self.0.disable().unwrap();
+        let count = self.0.read().unwrap();
+        measurements.add(phase, "instructions-retired".into(), count);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn sanity() {
+        if env::var("CI").is_ok() {
+            // If we find ourselves in a CI environment, skip this test: not all CI environments
+            // have perf events available (e.g. https://github.community/t/149164). Since this
+            // short-circuiting could be problematic in the future, we attempt to warn the user
+            // (hoping they have `--nocapture` set).
+            println!(
+                "Skipping the perf counters sanity test; it seems that this test is running \
+                 in a CI environment"
+            );
+            return;
+        }
+
+        let mut measurements = Measurements::new("arch".into(), "engine".into(), "wasm".into());
+        let mut measure = InstsRetiredMeasure::new();
+        measure.start(Phase::Compilation);
+        eprintln!("test test test...");
+        measure.end(Phase::Compilation, &mut measurements);
+        let measurements = measurements.finish();
+        println!("Measurements: {:?}", measurements);
+    }
+}

--- a/crates/recorder/src/measure/mod.rs
+++ b/crates/recorder/src/measure/mod.rs
@@ -79,6 +79,9 @@ pub trait Measure: 'static {
 
 #[cfg(target_os = "linux")]
 pub mod counters;
+#[cfg(target_os = "linux")]
+pub mod insts;
+
 pub mod cycles;
 pub mod noop;
 pub mod vtune;
@@ -94,13 +97,20 @@ pub mod vtune;
 pub enum MeasureType {
     /// No measurement.
     Noop,
+
     /// Measure cycles using, e.g., `RDTSC`.
     Cycles,
+
     /// Measure using VTune; this will return `0` values.
     VTune,
+
     /// Measure a combination of HW counters using `perf_event_open`.
     #[cfg(target_os = "linux")]
     PerfCounters,
+
+    /// Measure instructions retired.
+    #[cfg(target_os = "linux")]
+    InstsRetired,
 }
 
 impl fmt::Display for MeasureType {
@@ -111,6 +121,8 @@ impl fmt::Display for MeasureType {
             MeasureType::VTune => write!(f, "vtune"),
             #[cfg(target_os = "linux")]
             MeasureType::PerfCounters => write!(f, "perf-counters"),
+            #[cfg(target_os = "linux")]
+            MeasureType::InstsRetired => write!(f, "insts-retired"),
         }
     }
 }
@@ -124,6 +136,8 @@ impl FromStr for MeasureType {
             "vtune" => Ok(Self::VTune),
             #[cfg(target_os = "linux")]
             "perf-counters" => Ok(Self::PerfCounters),
+            #[cfg(target_os = "linux")]
+            "insts-retired" => Ok(Self::InstsRetired),
             _ => Err("unknown measure type"),
         }
     }
@@ -140,6 +154,8 @@ impl MeasureType {
             Self::VTune => Box::new(vtune::VTuneMeasure::new()),
             #[cfg(target_os = "linux")]
             Self::PerfCounters => Box::new(counters::CounterMeasure::new()),
+            #[cfg(target_os = "linux")]
+            Self::InstsRetired => Box::new(insts::InstsRetiredMeasure::new()),
         }
     }
 }


### PR DESCRIPTION
Simple measure, not a lot of different results like `perf-counters` has, and very stable / low noise.