### PR TITLE
Set nightly as the default toolchain in CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -32,5 +32,7 @@ jobs:
       with:
         default: true
         toolchain: nightly
+    - name: Check rust version
+      run: rustc --version
     - name: Run benchmarks
       run: benchmarks/run-all.sh

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -18,6 +18,7 @@ jobs:
     - name: Install nightly
       uses: actions-rs/toolchain@v1
       with:
+        default: true
         toolchain: nightly
     - name: Rebuild benchmarks
       run: benchmarks/build-all.sh 5
@@ -29,6 +30,7 @@ jobs:
     - name: Install nightly
       uses: actions-rs/toolchain@v1
       with:
+        default: true
         toolchain: nightly
     - name: Run benchmarks
       run: benchmarks/run-all.sh


### PR DESCRIPTION
So that random direct invocations of `rustc` or `cargo` in our CI scripts get the right version.