### PR TITLE
Disable `benchmark_effect_size` test on Windows

### DIFF
--- a/crates/cli/tests/all/benchmark.rs
+++ b/crates/cli/tests/all/benchmark.rs
@@ -128,6 +128,7 @@ fn benchmark_summary() {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)] // TODO: https://github.com/bytecodealliance/sightglass/issues/178
 fn benchmark_effect_size() -> anyhow::Result<()> {
     // Create a temporary copy of the test engine.
     let test_engine = test_engine();


### PR DESCRIPTION
As reported in #178, the `benchmark_effect_size` test on Windows occasionally fails with a strange error code and no output. This conditional `#[ignore]` temporarily avoids the issue until we can figure out what is going on.