### PR TITLE
Align ackermann output to its input

### DIFF
--- a/benchmarks/shootout-ackermann/stdout.expected
+++ b/benchmarks/shootout-ackermann/stdout.expected
@@ -1,2 +1,2 @@
-[ackermann] running with M = 0 and N = 0
+[ackermann] running with M = 3 and N = 7
 [ackermann] returned 1


### PR DESCRIPTION
In working on the patch #228 I found an issue with ackermann where I discovered there was a mismatch between the input and the output. 