### PR TITLE
Log "output" path when warning about missing "expected" path

### DIFF
--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -256,9 +256,10 @@ impl BenchmarkCommand {
         } else {
             log::warn!(
                 "Did not find `{}` for `{}`! Cannot assert that actual \
-                 `stdout` matches expectation.",
+                 `stdout` ({}) matches expectation.",
                 stdout_expected.display(),
-                wasm_file.display()
+                wasm_file.display(),
+                stdout.display()
             );
         }
 
@@ -282,9 +283,10 @@ impl BenchmarkCommand {
         } else {
             log::warn!(
                 "Did not find `{}` for `{}`! Cannot assert that actual \
-                 `stderr` matches expectation.",
+                 `stderr` ({}) matches expectation.",
                 stderr_expected.display(),
-                wasm_file.display()
+                wasm_file.display(),
+                stderr.display(),
             );
         }
 


### PR DESCRIPTION
Sightglass checks the benchmark's directory for `stdout.expected` and `stderr.expected` in order to compare these files with the actual execution output. Sightglass emits a logged warning when it cannot find the expected files to compare against. I observed warnings for `spidermonkey` and `meshoptimizer` but couldn't pick out which actual output files were theirs in the mass of `*.log` files. This change prints that output path in the warning. Once I looked at the output files for `spidermonkey` and `meshoptimizer` I realized there was nothing to worry about: both were 0-length files, as if the `stderr` stream had been opened but never written to.