### PR TITLE
Update Cargo edition to avoid warnings

### DIFF
--- a/benchmarks/blake3-scalar/rust-benchmark/Cargo.toml
+++ b/benchmarks/blake3-scalar/rust-benchmark/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blake3-wasm-benchmark"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 blake3 = "0.3.7"

--- a/benchmarks/image-classification/rust-benchmark/Cargo.toml
+++ b/benchmarks/image-classification/rust-benchmark/Cargo.toml
@@ -3,7 +3,7 @@ name = "image-classification-benchmark"
 version = "0.1.0"
 authors = ["The Bytecode Alliance Developers"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/benchmarks/pulldown-cmark/rust-benchmark/Cargo.toml
+++ b/benchmarks/pulldown-cmark/rust-benchmark/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pulldown-cmark-wasm-benchmark"
 version = "0.1.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This updates all crates to use `edition = "2021"` which should resolve
some Cargo warnings I was seeing:

> some crates are on edition 2021 which defaults to `resolver = "2"`,
> but virtual workspaces default to `resolver = "1"