### PR TITLE
Enable `clean` command

### DIFF
--- a/crates/cli/src/clean.rs
+++ b/crates/cli/src/clean.rs
@@ -2,16 +2,13 @@ use anyhow::{Context, Result};
 use regex::Regex;
 use structopt::StructOpt;
 
-/// Remove cached artifacts and log files.
+/// Remove the log files emitted in Sightglass runs.
 #[derive(StructOpt, Debug)]
-#[structopt(name = "validate")]
+#[structopt(name = "clean")]
 pub struct CleanCommand {}
 
 impl CleanCommand {
     pub fn execute(&self) -> Result<()> {
-        // Remove cached data, e.g. engines.
-        sightglass_build::clean()?;
-
         // Remove log files.
         let log_file_regex = Regex::new(r"^(stdout|stderr)\-\w+\-\d+-\d+.log$").unwrap();
         for entry in std::env::current_dir()?.read_dir()? {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,4 +1,5 @@
 mod benchmark;
+mod clean;
 mod effect_size;
 mod fingerprint;
 mod suite;
@@ -8,6 +9,7 @@ mod validate;
 
 use anyhow::Result;
 use benchmark::BenchmarkCommand;
+use clean::CleanCommand;
 use effect_size::EffectSizeCommand;
 use fingerprint::FingerprintCommand;
 use log::trace;
@@ -35,6 +37,7 @@ fn main() -> Result<()> {
 )]
 enum SightglassCommand {
     Benchmark(BenchmarkCommand),
+    Clean(CleanCommand),
     EffectSize(EffectSizeCommand),
     Fingerprint(FingerprintCommand),
     Summarize(SummarizeCommand),
@@ -47,6 +50,7 @@ impl SightglassCommand {
         trace!("Executing command: {:?}", &self);
         match self {
             SightglassCommand::Benchmark(benchmark) => benchmark.execute(),
+            SightglassCommand::Clean(clean) => clean.execute(),
             SightglassCommand::EffectSize(effect_size) => effect_size.execute(),
             SightglassCommand::Fingerprint(fingerprint) => fingerprint.execute(),
             SightglassCommand::Summarize(summarize) => summarize.execute(),


### PR DESCRIPTION
As @fitzgen noted in #250, the Sightglass CLI already has a way to clean up the log files that Sightglass emits--`sightglass-cli clean`. Unfortunately, some refactor removed this command from `main.rs`. This change adds it back.