### PR TITLE
Fix `clean.sh` script

### DIFF
--- a/benchmarks/clean.sh
+++ b/benchmarks/clean.sh
@@ -9,12 +9,12 @@
 # Usage: ./clean.sh
 
 set -e
-(set -x; rm -vf /tmp/sightglass-benchmark-*)
+(set -x; rm -vrf /tmp/sightglass-benchmark-*)
 CONTAINERS=$(docker ps -a | grep 'sightglass-benchmark' | awk '{print $1}')
 if [[ ! -z "$CONTAINERS" ]]; then
-    (set -x; docker rm "$CONTAINERS")
+    (set -x; echo $CONTAINERS | xargs docker rm)
 fi
 IMAGES=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'sightglass-benchmark')
 if [[ ! -z "$IMAGES" ]]; then
-    (set -x; docker rmi "$IMAGES")
+    (set -x; echo $IMAGES | xargs docker rmi)
 fi


### PR DESCRIPTION
Previously, this script tripped itself up when attempting to clean up the Docker artifacts created while building benchmarks. Using `xargs` fixes this.