### PR TITLE
Allow configuring which suite `run-all.sh` runs

### DIFF
--- a/benchmarks/run-all.sh
+++ b/benchmarks/run-all.sh
@@ -7,7 +7,7 @@
 set -e
 # From https://stackoverflow.com/a/246128:
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
-SUITE=$SCRIPT_DIR/all.suite
+SUITE=${SUITE:-$SCRIPT_DIR/all.suite}
 PROJECT_DIR=$(dirname $SCRIPT_DIR)
 SIGHTGLASS="cargo +nightly run --bin sightglass-cli --"
 ENGINE=$PROJECT_DIR/engines/wasmtime/libengine.so


### PR DESCRIPTION
In cases where we want to run all of the benchmarks from a suite different than `all.suite`, we can now do `SUITE=... run-all.sh`.