### PR TITLE
Add `simd.suite`

### DIFF
--- a/benchmarks/simd.suite
+++ b/benchmarks/simd.suite
@@ -1,0 +1,89 @@
+# These benchmarks use WebAssembly SIMD instructions. Inclusion in this list
+# does not guarantee that the benchmark is a SIMD-centric workload in the
+# measured section, only that SIMD instructions are present.
+#
+# These files were gathered by:
+# - creating a `find-simd.sh` script containing: `wasm2wat --disable-simd $1
+#   &>/dev/null || echo $1`
+# - running the script over the benchmarks: `find . -name '*.wasm' | xargs -L 1
+#   ./find-simd.sh`
+
+blake3-simd/benchmark.wasm
+hex-simd/benchmark.wasm
+intgemm-simd/benchmark.wasm
+meshoptimizer/benchmark.wasm
+libsodium/libsodium-aead_aes256gcm.wasm
+libsodium/libsodium-aead_aes256gcm2.wasm
+libsodium/libsodium-aead_chacha20poly1305.wasm
+libsodium/libsodium-aead_chacha20poly13052.wasm
+libsodium/libsodium-aead_xchacha20poly1305.wasm
+libsodium/libsodium-auth.wasm
+libsodium/libsodium-auth2.wasm
+libsodium/libsodium-auth3.wasm
+libsodium/libsodium-auth5.wasm
+libsodium/libsodium-auth6.wasm
+libsodium/libsodium-auth7.wasm
+libsodium/libsodium-box.wasm
+libsodium/libsodium-box2.wasm
+libsodium/libsodium-box7.wasm
+libsodium/libsodium-box8.wasm
+libsodium/libsodium-box_easy.wasm
+libsodium/libsodium-box_easy2.wasm
+libsodium/libsodium-box_seal.wasm
+libsodium/libsodium-box_seed.wasm
+libsodium/libsodium-chacha20.wasm
+libsodium/libsodium-codecs.wasm
+libsodium/libsodium-core1.wasm
+libsodium/libsodium-core2.wasm
+libsodium/libsodium-core3.wasm
+libsodium/libsodium-core4.wasm
+libsodium/libsodium-core5.wasm
+libsodium/libsodium-core6.wasm
+libsodium/libsodium-core_ed25519.wasm
+libsodium/libsodium-core_ristretto255.wasm
+libsodium/libsodium-ed25519_convert.wasm
+libsodium/libsodium-generichash.wasm
+libsodium/libsodium-generichash2.wasm
+libsodium/libsodium-generichash3.wasm
+libsodium/libsodium-hash.wasm
+libsodium/libsodium-hash3.wasm
+libsodium/libsodium-kdf.wasm
+libsodium/libsodium-keygen.wasm
+libsodium/libsodium-kx.wasm
+libsodium/libsodium-metamorphic.wasm
+libsodium/libsodium-misuse.wasm
+libsodium/libsodium-onetimeauth.wasm
+libsodium/libsodium-onetimeauth2.wasm
+libsodium/libsodium-onetimeauth7.wasm
+libsodium/libsodium-pwhash_argon2i.wasm
+libsodium/libsodium-pwhash_argon2id.wasm
+libsodium/libsodium-pwhash_scrypt.wasm
+libsodium/libsodium-pwhash_scrypt_ll.wasm
+libsodium/libsodium-randombytes.wasm
+libsodium/libsodium-scalarmult.wasm
+libsodium/libsodium-scalarmult2.wasm
+libsodium/libsodium-scalarmult5.wasm
+libsodium/libsodium-scalarmult6.wasm
+libsodium/libsodium-scalarmult7.wasm
+libsodium/libsodium-scalarmult8.wasm
+libsodium/libsodium-scalarmult_ed25519.wasm
+libsodium/libsodium-scalarmult_ristretto255.wasm
+libsodium/libsodium-secretbox.wasm
+libsodium/libsodium-secretbox2.wasm
+libsodium/libsodium-secretbox7.wasm
+libsodium/libsodium-secretbox8.wasm
+libsodium/libsodium-secretbox_easy.wasm
+libsodium/libsodium-secretbox_easy2.wasm
+libsodium/libsodium-secretstream.wasm
+libsodium/libsodium-shorthash.wasm
+libsodium/libsodium-sign.wasm
+libsodium/libsodium-siphashx24.wasm
+libsodium/libsodium-sodium_core.wasm
+libsodium/libsodium-sodium_utils.wasm
+libsodium/libsodium-sodium_version.wasm
+libsodium/libsodium-stream.wasm
+libsodium/libsodium-stream2.wasm
+libsodium/libsodium-stream3.wasm
+libsodium/libsodium-stream4.wasm
+libsodium/libsodium-verify1.wasm
+libsodium/libsodium-xchacha20.wasm


### PR DESCRIPTION
As discussed in a Cranelift meeting, it would be nice to know which benchmarks are SIMD users. This change adds a `simd.suite` file that lists the files that contain SIMD instructions. This can be run like:

```console
$ cargo run -- benchmark --engine .../libengine.so benchmarks/simd.suite
```

There are a couple ways this could be improved, but this may be fine as-is for now:
- `simd.suite` could get out of date; someone could create a CI check to keep it in-sync with the added files
- someone could really check that the measured section of each benchmark is actually a heavy SIMD user by collecting the instruction mix (e.g., `sde`)