### PR TITLE
Update instructions to run image-classify benchmark

### DIFF
--- a/benchmarks/image-classification/README.md
+++ b/benchmarks/image-classification/README.md
@@ -6,7 +6,7 @@ learning (ML). It uses the OpenVINO backend to identify the subject of the test 
 ## Steps to run this benchmark from the top sightglass directory
 - `./benchmarks/image-classification/setup.sh`
 - `source benchmarks/image-classification/openvino/setupvars.sh`
-- `cargo run -- benchmark --engine engines/wasmtime/libengine.so --engine-flags=--wasi-modules=experimental-wasi-nn -- benchmarks/image-classification/image-classification-benchmark.wasm`
+- `cargo run -- benchmark --engine engines/wasmtime/libengine.so --engine-flags=--wasi nn -- benchmarks/image-classification/image-classification-benchmark.wasm`
 ## Notes:
 - You must install and setup OpenVINO to run this benchmark. You can install OpenVINO and the other required files by running `setup.sh`. You'll also need to call `source benchmarks/image-classification/openvino/setupvars.sh` to set up the OpenVINO enviromnent variables each time you start a new terminal.
 - You must use `--engine-flags=--wasi-modules=experimental-wasi-nn` when running this benchmark. Otherwise Wasmtime won't link the required wasi-nn functions.

--- a/benchmarks/image-classification/setup.sh
+++ b/benchmarks/image-classification/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This will download a copy of OpenVINO and extract it locally, as well as the needed model files and test image. Once this script is run, you can use this command to run the benchmark:
-# cargo run -- benchmark benchmarks/image-classification/image-classification-benchmark.wasm --engine-flags="--wasi-modules=experimental-wasi-nn" --engine engines/wasmtime/libengine.so
+# cargo run -- benchmark benchmarks/image-classification/image-classification-benchmark.wasm --engine-flags="--wasi nn" --engine engines/wasmtime/libengine.so
 
 WASI_NN_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 FILENAME=l_openvino_toolkit_ubuntu20_2022.2.0.7713.af16ea1d79a_x86_64


### PR DESCRIPTION
Due to https://github.com/bytecodealliance/wasmtime/pull/6925 the run instructions for image-classify are no longer valid. Updating those instructions.