### PR TITLE
Update image-classification benchmark setup

### DIFF
--- a/benchmarks/image-classification/README.md
+++ b/benchmarks/image-classification/README.md
@@ -4,9 +4,8 @@ This benchmark uses [wasi-nn](https://github.com/WebAssembly/wasi-nn), a propose
 learning (ML). It uses the OpenVINO backend to identify the subject of the test image, and measures the time required for a single inference to run.
 
 ## Steps to run this benchmark from the top sightglass directory
-- `./benchmarks/image-classification/setup.sh`
-- `source benchmarks/image-classification/openvino/setupvars.sh`
+- `source ./benchmarks/image-classification/setup.sh`
 - `cargo run -- benchmark --engine engines/wasmtime/libengine.so --engine-flags=--wasi nn -- benchmarks/image-classification/image-classification-benchmark.wasm`
 ## Notes:
-- You must install and setup OpenVINO to run this benchmark. You can install OpenVINO and the other required files by running `setup.sh`. You'll also need to call `source benchmarks/image-classification/openvino/setupvars.sh` to set up the OpenVINO enviromnent variables each time you start a new terminal.
-- You must use `--engine-flags=--wasi-modules=experimental-wasi-nn` when running this benchmark. Otherwise Wasmtime won't link the required wasi-nn functions.
+- You must install and setup OpenVINO to run this benchmark. You can install OpenVINO and the other required files by sourcing `setup.sh` which also sets up the OpenVINO enviromnent variables. Do this each time you start a new terminal.
+- You must use `--engine-flags=--wasi-modules=--wasi nn` when running this benchmark. Otherwise Wasmtime won't link the required wasi-nn functions.

--- a/benchmarks/image-classification/setup.sh
+++ b/benchmarks/image-classification/setup.sh
@@ -11,3 +11,4 @@ MODEL=https://github.com/intel/openvino-rs/raw/main/crates/openvino/tests/fixtur
 [ ! -d ${WASI_NN_DIR}/openvino ] && wget -nc -q --no-check-certificate https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.2/linux/${FILENAME}.tgz -O ${WASI_NN_DIR}/${FILENAME}.tgz
 [ ! -d ${WASI_NN_DIR}/openvino ] && wget -nc -q --no-check-certificate https://storage.openvinotoolkit.org/repositories/openvino/packages/2022.2/linux/${FILENAME}.tgz -O ${WASI_NN_DIR}/${FILENAME}.tgz
 [ ! -d ${WASI_NN_DIR}/openvino ] && tar -C ${WASI_NN_DIR} -zxf ${WASI_NN_DIR}/${FILENAME}.tgz  && mv ${WASI_NN_DIR}/${FILENAME} ${WASI_NN_DIR}/openvino || echo "OpenVINO is already there, skipping..."
+. ${WASI_NN_DIR}/openvino/setupvars.sh


### PR DESCRIPTION
Addresses https://github.com/bytecodealliance/sightglass/issues/267
Combines 2-step setup into 1-step, now only `source ./benchmarks/image-classification/setup.sh` is needed.
Updated Readme to reflect this.
@jlb6740 