### PR TITLE
Round tract-onnx expected output to avoid false test failures

### DIFF
--- a/benchmarks/tract-onnx-image-classification/benchmark.stdout.expected
+++ b/benchmarks/tract-onnx-image-classification/benchmark.stdout.expected
@@ -1,1 +1,1 @@
-[Classification { label: "tiger", score: 17.559244 }, Classification { label: "tiger cat", score: 14.740076 }, Classification { label: "zebra", score: 12.357242 }]
+[Classification { label: "tiger", score: 17.56 }, Classification { label: "tiger cat", score: 14.74 }, Classification { label: "zebra", score: 12.36 }]

--- a/benchmarks/tract-onnx-image-classification/rust-benchmark/src/lib.rs
+++ b/benchmarks/tract-onnx-image-classification/rust-benchmark/src/lib.rs
@@ -78,7 +78,7 @@ fn classify(image: &[u8]) -> Result<Vec<Classification>, anyhow::Error> {
             .take(3)
             .map(|(score, i)| Classification {
                 label: LABELS[*i as usize].to_string(),
-                score: **score,
+                score: format!("{:.*}", 2, **score).parse().unwrap(),
             })
             .collect();
         Ok(labels)


### PR DESCRIPTION
Rounds classification scores to 2 decimal places and also modifies the corresponding expected output.