### PR TITLE
Allow benchmarking just one particular compilation/instantiation/execution phase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "crates/analysis",
     "crates/api",

--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -2,6 +2,7 @@ use crate::suite::BenchmarkOrSuite;
 use anyhow::{anyhow, Context, Result};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use sightglass_data::{Format, Measurement, Phase};
+use sightglass_recorder::bench_api::Engine;
 use sightglass_recorder::cpu_affinity::bind_to_single_core;
 use sightglass_recorder::measure::Measurements;
 use sightglass_recorder::{bench_api::BenchApi, benchmark::benchmark, measure::MeasureType};
@@ -197,18 +198,18 @@ impl BenchmarkCommand {
                     let stderr = Path::new(&stderr);
                     let stdin = None;
 
-                    benchmark(
+                    let engine = Engine::new(
                         &mut bench_api,
                         &working_dir,
                         stdout,
                         stderr,
                         stdin,
-                        &bytes,
-                        self.stop_after_phase.clone(),
-                        self.engine_flags.as_deref(),
-                        &mut measure,
                         &mut measurements,
-                    )?;
+                        &mut measure,
+                        self.engine_flags.as_deref(),
+                    );
+
+                    benchmark(engine, &bytes, self.stop_after_phase.clone())?;
 
                     self.check_output(Path::new(wasm_file), stdout, stderr)?;
                     measurements.next_iteration();

--- a/crates/cli/tests/all/benchmark.rs
+++ b/crates/cli/tests/all/benchmark.rs
@@ -5,14 +5,14 @@ use sightglass_data::Measurement;
 use std::path::PathBuf;
 
 #[test]
-fn benchmark_stop_after_compilation() {
+fn benchmark_phase_compilation() {
     sightglass_cli_benchmark()
         .arg("--raw")
         .arg("--processes")
         .arg("2")
         .arg("--iterations-per-process")
         .arg("1")
-        .arg("--stop-after")
+        .arg("--benchmark-phase")
         .arg("compilation")
         .arg(benchmark("noop"))
         .assert()
@@ -25,22 +25,44 @@ fn benchmark_stop_after_compilation() {
 }
 
 #[test]
-fn benchmark_stop_after_instantiation() {
+fn benchmark_phase_instantiation() {
     sightglass_cli_benchmark()
         .arg("--raw")
         .arg("--processes")
         .arg("2")
         .arg("--iterations-per-process")
         .arg("1")
-        .arg("--stop-after")
+        .arg("--benchmark-phase")
         .arg("instantiation")
         .arg(benchmark("noop"))
         .assert()
         .success()
         .stdout(
             predicate::str::contains("Compilation")
+                .not()
                 .and(predicate::str::contains("Instantiation"))
                 .and(predicate::str::contains("Execution").not()),
+        );
+}
+
+#[test]
+fn benchmark_phase_execution() {
+    sightglass_cli_benchmark()
+        .arg("--raw")
+        .arg("--processes")
+        .arg("2")
+        .arg("--iterations-per-process")
+        .arg("1")
+        .arg("--benchmark-phase")
+        .arg("execution")
+        .arg(benchmark("noop"))
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Compilation")
+                .not()
+                .and(predicate::str::contains("Instantiation").not())
+                .and(predicate::str::contains("Execution")),
         );
 }
 

--- a/crates/recorder/src/bench_api.rs
+++ b/crates/recorder/src/bench_api.rs
@@ -134,6 +134,11 @@ where
         }
     }
 
+    /// Get this engine's measurements.
+    pub fn measurements(&mut self) -> &mut Measurements<'c> {
+        unsafe { (*self.measurement_data).get_mut().1 }
+    }
+
     /// Compile the Wasm into a module.
     pub fn compile(self, wasm: &[u8]) -> Module<'a, 'b, 'c, M> {
         let result =
@@ -215,6 +220,11 @@ pub struct Module<'a, 'b, 'c, M> {
 }
 
 impl<'a, 'b, 'c, M> Module<'a, 'b, 'c, M> {
+    /// Turn this module back into an engine.
+    pub fn into_engine(self) -> Engine<'a, 'b, 'c, M> {
+        self.engine
+    }
+
     /// Instantiate this module, returning the resulting `Instance`.
     pub fn instantiate(self) -> Instance<'a, 'b, 'c, M> {
         let result = unsafe { (self.engine.bench_api.wasm_bench_instantiate)(self.engine.engine) };

--- a/crates/recorder/src/bench_api.rs
+++ b/crates/recorder/src/bench_api.rs
@@ -74,10 +74,7 @@ pub struct Engine<'a, 'b, 'c, M> {
     engine: *mut c_void,
 }
 
-impl<'a, 'b, 'c, M> Engine<'a, 'b, 'c, M>
-where
-    M: Measure,
-{
+impl<'a, 'b, 'c, M> Engine<'a, 'b, 'c, M> {
     /// Construct a new engine from the given `BenchApi`.
     // NB: take a mutable reference to the `BenchApi` so that no one else can
     // call its API methods out of order.
@@ -90,7 +87,10 @@ where
         measurements: &'a mut Measurements<'c>,
         measure: &'a mut M,
         execution_flags: Option<&'a str>,
-    ) -> Self {
+    ) -> Self
+    where
+        M: Measure,
+    {
         let working_dir = working_dir.display().to_string();
         let stdout_path = stdout_path.display().to_string();
         let stderr_path = stderr_path.display().to_string();
@@ -148,7 +148,10 @@ where
     }
 
     /// Bench API callback for the start of compilation.
-    extern "C" fn compilation_start(data: *mut u8) {
+    extern "C" fn compilation_start(data: *mut u8)
+    where
+        M: Measure,
+    {
         log::debug!("Starting compilation measurement");
         let data = data as *mut (*mut M, *mut Measurements<'b>);
         let measure = unsafe { data.as_mut().unwrap().0.as_mut().unwrap() };
@@ -156,7 +159,10 @@ where
     }
 
     /// Bench API callback for the start of instantiation.
-    extern "C" fn instantiation_start(data: *mut u8) {
+    extern "C" fn instantiation_start(data: *mut u8)
+    where
+        M: Measure,
+    {
         log::debug!("Starting instantiation measurement");
         let data = data as *mut (*mut M, *mut Measurements<'b>);
         let measure = unsafe { data.as_mut().unwrap().0.as_mut().unwrap() };
@@ -164,7 +170,10 @@ where
     }
 
     /// Bench API callback for the start of execution.
-    extern "C" fn execution_start(data: *mut u8) {
+    extern "C" fn execution_start(data: *mut u8)
+    where
+        M: Measure,
+    {
         log::debug!("Starting execution measurement");
         let data = data as *mut (*mut M, *mut Measurements<'b>);
         let measure = unsafe { data.as_mut().unwrap().0.as_mut().unwrap() };
@@ -172,7 +181,10 @@ where
     }
 
     /// Bench API callback for the end of compilation.
-    extern "C" fn compilation_end(data: *mut u8) {
+    extern "C" fn compilation_end(data: *mut u8)
+    where
+        M: Measure,
+    {
         let data = data as *mut (*mut M, *mut Measurements<'b>);
         let (measure, measurements) = unsafe {
             let data = data.as_mut().unwrap();
@@ -183,7 +195,10 @@ where
     }
 
     /// Bench API callback for the end of instantiation.
-    extern "C" fn instantiation_end(data: *mut u8) {
+    extern "C" fn instantiation_end(data: *mut u8)
+    where
+        M: Measure,
+    {
         let data = data as *mut (*mut M, *mut Measurements<'b>);
         let (measure, measurements) = unsafe {
             let data = data.as_mut().unwrap();
@@ -194,7 +209,10 @@ where
     }
 
     /// Bench API callback for the end of execution.
-    extern "C" fn execution_end(data: *mut u8) {
+    extern "C" fn execution_end(data: *mut u8)
+    where
+        M: Measure,
+    {
         let data = data as *mut (*mut M, *mut Measurements<'b>);
         let (measure, measurements) = unsafe {
             let data = data.as_mut().unwrap();
@@ -223,6 +241,11 @@ impl<'a, 'b, 'c, M> Module<'a, 'b, 'c, M> {
     /// Turn this module back into an engine.
     pub fn into_engine(self) -> Engine<'a, 'b, 'c, M> {
         self.engine
+    }
+
+    /// Get this engine's measurements.
+    pub fn measurements(&mut self) -> &mut Measurements<'c> {
+        self.engine.measurements()
     }
 
     /// Instantiate this module, returning the resulting `Instance`.

--- a/crates/recorder/src/benchmark.rs
+++ b/crates/recorder/src/benchmark.rs
@@ -1,9 +1,8 @@
-use crate::bench_api::{BenchApi, Engine};
-use crate::measure::{Measure, Measurements};
+use crate::bench_api::Engine;
+use crate::measure::Measure;
 use anyhow::Result;
 use log::info;
 use sightglass_data::Phase;
-use std::path::Path;
 
 /// Measure various phases of a Wasm module's lifetime.
 ///
@@ -12,33 +11,15 @@ use std::path::Path;
 ///
 /// Optionally stop after the given `stop_after_phase`, rather than running all
 /// phases.
-pub fn benchmark<'a, 'b, 'c>(
-    bench_api: &'a mut BenchApi<'b>,
-    working_dir: &Path,
-    stdout_path: &Path,
-    stderr_path: &Path,
-    stdin_path: Option<&Path>,
+pub fn benchmark<'a, 'b, 'c, M: Measure>(
+    engine: Engine<'_, '_, '_, M>,
     wasm_bytes: &[u8],
     stop_after_phase: Option<Phase>,
-    execution_flags: Option<&str>,
-    measure: &'a mut impl Measure,
-    measurements: &'a mut Measurements<'c>,
 ) -> Result<()> {
     #[cfg(target_os = "linux")]
     info!("Benchmark scheduled on CPU: {}", unsafe {
         libc::sched_getcpu()
     });
-
-    let engine = Engine::new(
-        bench_api,
-        working_dir,
-        stdout_path,
-        stderr_path,
-        stdin_path,
-        measurements,
-        measure,
-        execution_flags,
-    );
 
     // Measure the module compilation.
     let module = engine.compile(wasm_bytes);

--- a/crates/recorder/src/benchmark.rs
+++ b/crates/recorder/src/benchmark.rs
@@ -12,10 +12,10 @@ use sightglass_data::Phase;
 /// Optionally stop after the given `stop_after_phase`, rather than running all
 /// phases.
 pub fn benchmark<'a, 'b, 'c, M: Measure>(
-    engine: Engine<'_, '_, '_, M>,
+    engine: Engine<'a, 'b, 'c, M>,
     wasm_bytes: &[u8],
     stop_after_phase: Option<Phase>,
-) -> Result<()> {
+) -> Result<Engine<'a, 'b, 'c, M>> {
     #[cfg(target_os = "linux")]
     info!("Benchmark scheduled on CPU: {}", unsafe {
         libc::sched_getcpu()
@@ -26,7 +26,7 @@ pub fn benchmark<'a, 'b, 'c, M: Measure>(
     info!("Compiled successfully");
 
     if stop_after_phase == Some(Phase::Compilation) {
-        return Ok(());
+        return Ok(module.into_engine());
     }
 
     // Measure the module instantiation.
@@ -34,11 +34,11 @@ pub fn benchmark<'a, 'b, 'c, M: Measure>(
     info!("Instantiated successfully");
 
     if stop_after_phase == Some(Phase::Instantiation) {
-        return Ok(());
+        return Ok(instance.into_module().into_engine());
     }
 
-    instance.execute();
+    let module = instance.execute();
     info!("Executed successfully");
 
-    Ok(())
+    Ok(module.into_engine())
 }

--- a/crates/recorder/src/benchmark.rs
+++ b/crates/recorder/src/benchmark.rs
@@ -1,20 +1,13 @@
-use crate::bench_api::Engine;
+use crate::bench_api::{Engine, Module};
 use crate::measure::Measure;
 use anyhow::Result;
 use log::info;
-use sightglass_data::Phase;
 
-/// Measure various phases of a Wasm module's lifetime.
-///
-/// Provide paths to files created for logging the Wasm's `stdout` and `stderr`
-/// and (optionally) a file read and piped into the Wasm execution as `stdin`.
-///
-/// Optionally stop after the given `stop_after_phase`, rather than running all
-/// phases.
-pub fn benchmark<'a, 'b, 'c, M: Measure>(
+/// Measure all phases of a Wasm module's lifetime: compilation, instantiation,
+/// and execution.
+pub fn all<'a, 'b, 'c, M: Measure>(
     engine: Engine<'a, 'b, 'c, M>,
     wasm_bytes: &[u8],
-    stop_after_phase: Option<Phase>,
 ) -> Result<Engine<'a, 'b, 'c, M>> {
     #[cfg(target_os = "linux")]
     info!("Benchmark scheduled on CPU: {}", unsafe {
@@ -25,20 +18,51 @@ pub fn benchmark<'a, 'b, 'c, M: Measure>(
     let module = engine.compile(wasm_bytes);
     info!("Compiled successfully");
 
-    if stop_after_phase == Some(Phase::Compilation) {
-        return Ok(module.into_engine());
-    }
-
     // Measure the module instantiation.
     let instance = module.instantiate();
     info!("Instantiated successfully");
-
-    if stop_after_phase == Some(Phase::Instantiation) {
-        return Ok(instance.into_module().into_engine());
-    }
 
     let module = instance.execute();
     info!("Executed successfully");
 
     Ok(module.into_engine())
+}
+
+/// Measure just the compilation phase of a Wasm module's lifetime.
+pub fn compilation<'a, 'b, 'c, M: Measure>(
+    engine: Engine<'a, 'b, 'c, M>,
+    wasm_bytes: &[u8],
+) -> Result<Engine<'a, 'b, 'c, M>> {
+    #[cfg(target_os = "linux")]
+    info!("Benchmark scheduled on CPU: {}", unsafe {
+        libc::sched_getcpu()
+    });
+
+    let module = engine.compile(wasm_bytes);
+    info!("Compiled successfully");
+
+    Ok(module.into_engine())
+}
+
+/// Measure just the instantiation phase of a Wasm module's lifetime.
+pub fn instantiation<'a, 'b, 'c, M: Measure>(
+    module: Module<'a, 'b, 'c, M>,
+) -> Result<Module<'a, 'b, 'c, M>> {
+    let instance = module.instantiate();
+    info!("Instantiated successfully");
+
+    Ok(instance.into_module())
+}
+
+/// Measure just the execution phase of a Wasm module's lifetime.
+pub fn execution<'a, 'b, 'c, M: Measure>(
+    module: Module<'a, 'b, 'c, M>,
+) -> Result<Module<'a, 'b, 'c, M>> {
+    let instance = module.instantiate();
+    info!("Instantiated successfully");
+
+    let module = instance.execute();
+    info!("Executed successfully");
+
+    Ok(module)
 }


### PR DESCRIPTION
This avoids recompiling the Wasm module many times when we are only interested
in benchmarking instantiation or execution. Note that it is still compiled once
per process, but you can compile it exactly once if you do `--processes 1`.

cc @alexcrichton 