### PR TITLE
Correct gitignore patterns for logs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ benchmarks/**/*.ll
 benchmarks/**/*.o
 
 # Log files produced by running sightglass benchmarks.
-**/stdout-*-*-*.log
-**/stderr-*-*-*.log
+**/stdout-*-*.log
+**/stderr-*-*.log


### PR DESCRIPTION
At some point, we changed from 3-part filenames to 2-part ones (wasm hash + process ID).