### PR TITLE
Time Measure & Support for Multiple Measures

### DIFF
--- a/crates/recorder/src/measure/mod.rs
+++ b/crates/recorder/src/measure/mod.rs
@@ -83,6 +83,7 @@ pub mod counters;
 pub mod insts;
 
 pub mod cycles;
+pub mod multi;
 pub mod noop;
 pub mod time;
 pub mod vtune;

--- a/crates/recorder/src/measure/mod.rs
+++ b/crates/recorder/src/measure/mod.rs
@@ -84,6 +84,7 @@ pub mod insts;
 
 pub mod cycles;
 pub mod noop;
+pub mod time;
 pub mod vtune;
 
 /// [MeasureType] enumerates the implementations of [Measure] and allows us to `build` an instance
@@ -97,6 +98,9 @@ pub mod vtune;
 pub enum MeasureType {
     /// No measurement.
     Noop,
+
+    /// Simple time measurement.
+    Time,
 
     /// Measure cycles using, e.g., `RDTSC`.
     Cycles,
@@ -117,6 +121,7 @@ impl fmt::Display for MeasureType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             MeasureType::Noop => write!(f, "noop"),
+            MeasureType::Time => write!(f, "time"),
             MeasureType::Cycles => write!(f, "cycles"),
             MeasureType::VTune => write!(f, "vtune"),
             #[cfg(target_os = "linux")]
@@ -132,6 +137,7 @@ impl FromStr for MeasureType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "noop" => Ok(Self::Noop),
+            "time" => Ok(Self::Time),
             "cycles" => Ok(Self::Cycles),
             "vtune" => Ok(Self::VTune),
             #[cfg(target_os = "linux")]
@@ -150,6 +156,7 @@ impl MeasureType {
     pub fn build(&self) -> Box<dyn Measure> {
         match self {
             Self::Noop => Box::new(noop::NoopMeasure::new()),
+            Self::Time => Box::new(time::TimeMeasure::new()),
             Self::Cycles => Box::new(cycles::CycleMeasure::new()),
             Self::VTune => Box::new(vtune::VTuneMeasure::new()),
             #[cfg(target_os = "linux")]

--- a/crates/recorder/src/measure/multi.rs
+++ b/crates/recorder/src/measure/multi.rs
@@ -1,0 +1,35 @@
+//! Multiplexing measurement in order to take multiple measures
+//! from a single entry point.
+
+use sightglass_data::Phase;
+
+use super::{Measure, Measurements};
+
+pub struct MultiMeasure {
+    measures: Vec<Box<dyn Measure>>,
+}
+
+impl MultiMeasure {
+    pub fn new<I>(measures: I) -> Self
+    where
+        I: IntoIterator<Item = Box<dyn Measure>>,
+    {
+        Self {
+            measures: measures.into_iter().collect(),
+        }
+    }
+}
+
+impl Measure for MultiMeasure {
+    fn start(&mut self, phase: Phase) {
+        for measure in self.measures.iter_mut() {
+            measure.start(phase)
+        }
+    }
+
+    fn end(&mut self, phase: Phase, measurements: &mut Measurements) {
+        for measure in self.measures.iter_mut() {
+            measure.end(phase, measurements)
+        }
+    }
+}

--- a/crates/recorder/src/measure/time.rs
+++ b/crates/recorder/src/measure/time.rs
@@ -1,0 +1,29 @@
+//! Measure time elapsed time for each benchmark; note that this is
+//! often probably not the best measurement as, unlike cycle counts,
+//! there are likely additional external factors that could skew
+//! results (such as cpu frequency scaling, etc.).
+
+use std::time::Instant;
+
+use super::{Measure, Measurements};
+use sightglass_data::Phase;
+
+pub struct TimeMeasure(Option<Instant>);
+
+impl TimeMeasure {
+    pub fn new() -> Self {
+        Self(None)
+    }
+}
+
+impl Measure for TimeMeasure {
+    fn start(&mut self, _phase: Phase) {
+        let start = Instant::now();
+        self.0 = Some(start);
+    }
+
+    fn end(&mut self, phase: Phase, measurements: &mut Measurements) {
+        let elapsed = self.0.take().unwrap().elapsed();
+        measurements.add(phase, "nanoseconds".into(), elapsed.as_nanos() as u64);
+    }
+}


### PR DESCRIPTION
You can now, for example, do the following to capture timing, cycles, and perf-counters data on a single run...

```
cargo run -- benchmark \
    --engine engines/wasmtime/libengine.dylib \
    --raw -o result.json \
    -m time -m cycles -m perf-counters \
    -- benchmarks/all.suite
```