### PR TITLE
bump spidermonkey benchmark

### DIFF
--- a/benchmarks/spidermonkey/Dockerfile
+++ b/benchmarks/spidermonkey/Dockerfile
@@ -7,16 +7,16 @@ ENV PATH=/root/.cargo/bin:$PATH
 
 # Build SpiderMonkey itself.
 WORKDIR /usr/src
-RUN git clone https://github.com/tschneidereit/spidermonkey-wasi-embedding
+RUN git clone -b rev_b02d76023a15a3fa8c8f54bff5dac91099669003 --single-branch https://github.com/tschneidereit/spidermonkey-wasi-embedding
 WORKDIR /usr/src/spidermonkey-wasi-embedding
 ENV DEBIAN_FRONTEND=noninteractive
-RUN ./build-engine.sh
+RUN ./download-engine.sh
 
 RUN apt-get -y install wget
 WORKDIR /opt
-RUN wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-14/wasi-sdk-14.0-linux.tar.gz
-RUN tar zxvf wasi-sdk-14.0-linux.tar.gz
-RUN ln -s wasi-sdk-14.0 wasi-sdk
+RUN wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-x86_64-linux.tar.gz
+RUN tar zxvf wasi-sdk-25.0-x86_64-linux.tar.gz
+RUN ln -s wasi-sdk-25.0-x86_64-linux wasi-sdk
 
 RUN apt-get -y install xxd
 

--- a/benchmarks/spidermonkey/build.sh
+++ b/benchmarks/spidermonkey/build.sh
@@ -7,6 +7,7 @@ SM=/usr/src/spidermonkey-wasi-embedding
 xxd -i js/marked.min.js > marked_js.h
 xxd -i js/main.js > main_js.h
 
-/opt/wasi-sdk/bin/clang++ -O3 -std=c++17 -o /benchmark.wasm runtime.cpp -I$SM/release/include/ $SM/release/lib/*.o $SM/release/lib/*.a
+mkdir -p /benchmark
+/opt/wasi-sdk/bin/clang++ -lwasi-emulated-getpid -O3 -std=c++17 -o /benchmark/benchmark.wasm runtime.cpp -I$SM/release/include/ $SM/release/lib/*.o $SM/release/lib/*.a
 
-/opt/wasi-sdk/bin/strip /benchmark.wasm
+/opt/wasi-sdk/bin/strip /benchmark/benchmark.wasm

--- a/benchmarks/spidermonkey/runtime.cpp
+++ b/benchmarks/spidermonkey/runtime.cpp
@@ -62,21 +62,9 @@ bool init_js() {
   if (!js::UseInternalJobQueues(cx) || !JS::InitSelfHostedCode(cx))
       return false;
 
-  JS::ContextOptionsRef(cx)
-    .setPrivateClassFields(true)
-    .setPrivateClassMethods(true)
-    .setClassStaticBlocks(true)
-    .setErgnomicBrandChecks(true);
-
   JS::RealmOptions options;
   options.creationOptions()
-    .setStreamsEnabled(true)
-    .setReadableByteStreamsEnabled(true)
-    .setBYOBStreamReadersEnabled(true)
-    .setReadableStreamPipeToEnabled(true)
-    .setWritableStreamsEnabled(true)
-    .setIteratorHelpersEnabled(true)
-    .setWeakRefsEnabled(JS::WeakRefSpecifier::EnabledWithoutCleanupSome);
+    .setStreamsEnabled(true);
 
   RootedObject global(cx, JS_NewGlobalObject(cx, &global_class, nullptr, JS::FireOnNewGlobalHook,
                                              options));


### PR DESCRIPTION
The current `Dockerfile` doesn't pin the version of `spidermonkey-wasi-embedding`, so `docker build` cannot run, due to the mismatch of versions. This PR also bumps spidermonkey to the latest release.