### PR TITLE
Report the confidence interval as 0.0 when there is no variance

### DIFF
--- a/crates/analysis/src/effect_size.rs
+++ b/crates/analysis/src/effect_size.rs
@@ -57,7 +57,7 @@ pub fn calculate<'a>(
             .map(|m| m.count as f64)
             .collect();
 
-        let ci = behrens_fisher::confidence_interval(1.0 - significance_level, a, b)?;
+        let ci = behrens_fisher::confidence_interval(1.0 - significance_level, a, b).unwrap_or(0.0);
         results.push(EffectSize {
             arch: key.arch.unwrap(),
             wasm: key.wasm.unwrap(),


### PR DESCRIPTION
This is both better UX (no single error prevents viewing the rest of the non-error results) and more accurate (if there is no variance then we know the exact delta).