### PR TITLE
feat: add callgrind measure

### DIFF
--- a/.github/scripts/callgrind.mjs
+++ b/.github/scripts/callgrind.mjs
@@ -1,0 +1,169 @@
+// Run `$BENCHMARKS` under Valgrind's Callgrind with the `callgrind` measure
+// for the `callgrind` workflow; see `callgrind.yml`.
+
+import { strict as assert } from "node:assert";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+
+/// Run a command with inherited stdio, throwing if it fails.
+function exec(file, args) {
+  const result = spawnSync(file, args, { stdio: "inherit" });
+  assert.equal(
+    result.status,
+    0,
+    `\`${file} ${args.join(" ")}\` exited with ${result.status}`,
+  );
+}
+
+/// Shorten a benchmark's wasm path to a human-friendly name, e.g.
+/// `benchmarks/bz2/benchmark.wasm` to `bz2` and
+/// `benchmarks/cm-online-stats/cm-online-stats.wasm` to `cm-online-stats`.
+function shortName(wasm) {
+  const name = wasm
+    .replace(/^.*benchmarks\//, "")
+    .replace(/\.wasm$/, "")
+    .replace(/\/benchmark$/, "");
+  const parts = name.split("/");
+  return parts.length === 2 && parts[0] === parts[1] ? parts[0] : name;
+}
+
+/// Run the benchmarks, render a summary table, check the results, and (with
+/// at least three iterations) generate an HTML report. Everything is left in
+/// the `callgrind-results` directory for upload as a workflow artifact.
+async function main() {
+  const benchmarks = (process.env.BENCHMARKS || process.env.DEFAULT_BENCHMARKS)
+    .split(/\s+/)
+    .filter(Boolean);
+  const iterations = parseInt(process.env.ITERATIONS || "1", 10);
+
+  // `sightglass-cli` launches each benchmark process under Valgrind's
+  // Callgrind itself when the `callgrind` measure is selected. (Valgrind is
+  // installed by the workflow before sightglass is even built: the Valgrind
+  // headers must be present at build time.)
+  const run = spawnSync(
+    "target/debug/sightglass-cli",
+    [
+      "benchmark",
+      "--engine",
+      "engines/wasmtime/libengine.so",
+      "--measure",
+      "callgrind",
+      "--processes",
+      "1",
+      "--iterations-per-process",
+      String(iterations),
+      "--small-workloads",
+      "--raw",
+      "--output-format",
+      "json",
+      "--",
+      ...benchmarks,
+    ],
+    {
+      stdio: ["ignore", "pipe", "inherit"],
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  );
+  console.log(run.stdout);
+  assert.equal(run.status, 0, `sightglass-cli exited with ${run.status}`);
+
+  fs.mkdirSync("callgrind-results");
+  fs.writeFileSync("callgrind-results/results.json", run.stdout);
+  for (const file of fs.readdirSync(".")) {
+    if (file.startsWith("callgrind.out.")) {
+      fs.renameSync(file, `callgrind-results/${file}`);
+    }
+  }
+
+  // Group the measurements by benchmark.
+  const byWasm = new Map();
+  for (const m of JSON.parse(run.stdout)) {
+    if (m.event !== "callgrind-ir") {
+      continue;
+    }
+    if (!byWasm.has(m.wasm)) {
+      byWasm.set(m.wasm, []);
+    }
+    byWasm.get(m.wasm).push(m);
+  }
+
+  // Display each benchmark by its short name, unless two benchmarks share one.
+  const displayNames = new Map();
+  {
+    const occurrences = new Map();
+    for (const wasm of byWasm.keys()) {
+      const name = shortName(wasm);
+      occurrences.set(name, (occurrences.get(name) ?? 0) + 1);
+    }
+    for (const wasm of byWasm.keys()) {
+      const name = shortName(wasm);
+      displayNames.set(wasm, occurrences.get(name) === 1 ? name : wasm);
+    }
+  }
+
+  // A phase's instruction counts across iterations; deterministic counts
+  // collapse to a single value.
+  const phaseCounts = (ms, phase) => {
+    const counts = new Set(
+      ms.filter((m) => m.phase === phase).map((m) => m.count),
+    );
+    return [...counts].join(" / ");
+  };
+
+  // Render a table of the results on the workflow run's summary page. This
+  // happens before the checks below so that a failing run still reports what
+  // it measured.
+  const summary = [
+    "### Callgrind instruction counts (`callgrind-ir`)",
+    "",
+    `Engine: \`wasmtime@${process.env.WASMTIME_SHA}\``,
+    "",
+    "| Benchmark | Compilation | Instantiation | Execution |",
+    "| --- | ---: | ---: | ---: |",
+    ...[...byWasm.entries()].map(([wasm, ms]) => {
+      const phases = ["Compilation", "Instantiation", "Execution"]
+        .map((phase) => phaseCounts(ms, phase))
+        .join(" | ");
+      return `| ${displayNames.get(wasm)} | ${phases} |`;
+    }),
+    "",
+    "Distinct counts across iterations are shown separated by ` / `; the raw" +
+      " per-phase Callgrind dumps and the JSON measurements are available in" +
+      " the `callgrind-results` artifact.",
+    "",
+  ].join("\n");
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+
+  // Every benchmark must have recorded an instruction count for each of its
+  // three phases on every iteration.
+  assert.ok(byWasm.size >= 1, "no benchmarks were measured");
+  for (const [wasm, ms] of byWasm) {
+    assert.equal(
+      ms.length,
+      3 * iterations,
+      `wrong number of instruction counts for ${wasm}`,
+    );
+  }
+
+  // With enough samples, also generate an HTML report.
+  if (iterations >= 3) {
+    exec("target/debug/sightglass-cli", [
+      "report",
+      "-i",
+      "json",
+      "--event",
+      "callgrind-ir",
+      "--phase",
+      "execution",
+      "-o",
+      "callgrind-results/report.html",
+      "callgrind-results/results.json",
+    ]);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.github/scripts/resolve-wasmtime-ref.mjs
+++ b/.github/scripts/resolve-wasmtime-ref.mjs
@@ -1,0 +1,33 @@
+// Resolve `WASMTIME_REF` (a branch, a tag, or a full commit hash; `main` by
+// default) to a full commit hash and emit it as the step's `sha` output. Used
+// by the `callgrind` workflow; see `callgrind.yml`.
+
+import { strict as assert } from "node:assert";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+
+const WASMTIME_REPOSITORY = "https://github.com/bytecodealliance/wasmtime/";
+
+async function main() {
+  const ref = process.env.WASMTIME_REF || "main";
+  let sha;
+  if (/^[0-9a-f]{40}$/.test(ref)) {
+    sha = ref;
+  } else {
+    const refs = execFileSync("git", ["ls-remote", WASMTIME_REPOSITORY, ref], {
+      encoding: "utf8",
+    });
+    sha = refs.split("\n")[0]?.split("\t")[0];
+  }
+  assert.match(
+    sha ?? "",
+    /^[0-9a-f]{40}$/,
+    `unable to resolve wasmtime ref \`${ref}\``,
+  );
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `sha=${sha}\n`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.github/workflows/callgrind.yml
+++ b/.github/workflows/callgrind.yml
@@ -1,0 +1,127 @@
+name: callgrind
+
+# Run benchmarks with the `callgrind` measure,
+# recording deterministic per-phase instruction counts against the latest
+# wasmtime commit. The JSON measurements and the raw per-phase Callgrind dump
+# files are uploaded as a workflow artifact, and a summary table is rendered on
+# the workflow run page.
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    # Run nightly at 04:23 UTC.
+    - cron: "23 4 * * *"
+  workflow_dispatch:
+    inputs:
+      benchmarks:
+        description: >-
+          Space-separated benchmark `.wasm` (or `.suite`) paths to run.
+          Defaults to the default suite -- minus spidermonkey, whose large
+          module takes too long to compile under Callgrind's (serialized)
+          simulation -- plus the component-model benchmark.
+        required: false
+        default: ""
+      iterations:
+        description: >-
+          Iterations per process. The instruction counts are deterministic so
+          `1` is usually enough; use `3` or more to also generate an HTML
+          report in the artifact.
+        required: false
+        default: "1"
+      wasmtime-ref:
+        description: >-
+          The wasmtime revision to benchmark: a branch, a tag, or a full
+          commit hash. Defaults to `main`.
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_LOG: info
+  DEFAULT_BENCHMARKS: >-
+    benchmarks/noop/benchmark.wasm
+    benchmarks/bz2/benchmark.wasm
+    benchmarks/pulldown-cmark/benchmark.wasm
+    benchmarks/cm-online-stats/cm-online-stats.wasm
+
+jobs:
+  callgrind:
+    # Don't run scheduled jobs on forks.
+    if: github.event_name != 'schedule' || github.repository == 'bytecodealliance/sightglass'
+    runs-on: ubuntu-latest
+    # The default benchmark set takes well under an hour, but leave headroom
+    # for `workflow_dispatch` runs over larger benchmark sets or with more
+    # iterations.
+    timeout-minutes: 120
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+    - run: rustup update
+
+    # Benchmark against the requested wasmtime revision (the latest commit on
+    # `main` by default), caching the built engine by commit hash so that
+    # back-to-back runs do not rebuild it.
+    - name: Resolve the wasmtime revision
+      id: wasmtime
+      env:
+        WASMTIME_REF: ${{ inputs.wasmtime-ref }}
+      run: node .github/scripts/resolve-wasmtime-ref.mjs
+    - name: Download cached wasmtime engine
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      id: wasmtime-cache
+      with:
+        path: engines/wasmtime/*
+        key: callgrind-wasmtime-${{ runner.os }}-${{ steps.wasmtime.outputs.sha }}
+    - name: Build wasmtime engine
+      if: steps.wasmtime-cache.outputs.cache-hit != 'true'
+      working-directory: ./engines/wasmtime
+      env:
+        REVISION: ${{ steps.wasmtime.outputs.sha }}
+      run: |
+        rustc build.rs
+        ./build
+
+    # Cache the cargo registry and build artifacts for the sightglass-cli
+    # build. `cargo build` still runs below to pick up any source changes; a
+    # warm cache makes it incremental.
+    - name: Cache sightglass-cli build
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: callgrind-sightglass-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+        restore-keys: |
+          callgrind-sightglass-${{ runner.os }}-
+
+    # Valgrind must be installed BEFORE building sightglass: the Valgrind
+    # client-request support in sightglass-recorder is only compiled in when
+    # the Valgrind headers are present at build time.
+    - name: Install valgrind
+      run: |
+        sudo apt-get update -q
+        sudo apt-get install -y -q valgrind
+
+    - name: Build sightglass-cli
+      run: cargo build
+
+    - name: Benchmark with the callgrind measure
+      env:
+        BENCHMARKS: ${{ inputs.benchmarks }}
+        ITERATIONS: ${{ inputs.iterations }}
+        WASMTIME_SHA: ${{ steps.wasmtime.outputs.sha }}
+      run: node .github/scripts/callgrind.mjs
+
+    - name: Upload callgrind results
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: callgrind-results
+        path: callgrind-results/
+        if-no-files-found: warn

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.109",
+]
+
+[[package]]
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +218,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +249,17 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -368,6 +408,12 @@ checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "darling"
@@ -832,6 +878,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +921,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1243,6 +1301,16 @@ dependencies = [
 
 [[package]]
 name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if 1.0.4",
+ "windows-link",
+]
+
+[[package]]
+name = "libloading"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
@@ -1355,6 +1423,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,6 +1477,16 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -1805,6 +1889,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.109",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2149,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,7 +2407,7 @@ dependencies = [
  "assert_cmd",
  "csv",
  "env_logger 0.8.4",
- "libloading",
+ "libloading 0.9.0",
  "log",
  "minijinja",
  "predicates 1.0.8",
@@ -2356,7 +2465,7 @@ dependencies = [
  "ittapi",
  "lazy_static",
  "libc",
- "libloading",
+ "libloading 0.9.0",
  "log",
  "perf-event",
  "precision",
@@ -2365,6 +2474,7 @@ dependencies = [
  "sightglass-build",
  "sightglass-data",
  "thiserror",
+ "valgrind-requests",
  "wat",
 ]
 
@@ -2489,11 +2599,32 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.109",
 ]
 
 [[package]]
@@ -2818,6 +2949,21 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valgrind-requests"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796c44118a551cc842f2ce6fce4983b86e282ec99b6b5e80b09dfeab830e7755"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cfg-if 1.0.4",
+ "cty",
+ "regex",
+ "rustc_version",
+ "strum",
+]
 
 [[package]]
 name = "vcpkg"

--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ Several _measures_ can be configured using the `--measure` option:
   instructions retired, cache accesses, cache misses); only available on Linux
 - `vtune`: record each phase as a VTune task for analysis; see [this help
   documentation](docs/vtune.md) for more details
+- `callgrind`: (nearly)deterministic instruction count measurement using
+  Valgrind's Callgrind, which must be installed, including when building
+  `sightglass-cli` itself, since the Valgrind headers are needed to compile
+  the support in; `sightglass-cli` launches each benchmark process under
+  `valgrind` itself (wrapping `sightglass-cli` in `valgrind` manually also
+  works, with `--processes 1`); only available on Linux
 - `noop`: no measurement is performed
 
 For example, run:

--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -92,7 +92,8 @@ pub struct BenchmarkCommand {
     #[structopt(short = "o", long = "output-file")]
     output_file: Option<String>,
 
-    /// The type of measurement to use (cycles, insts-retired, perf-counters, noop, vtune)
+    /// The type of measurement to use (cycles, insts-retired, perf-counters, noop, vtune,
+    /// callgrind)
     /// when recording the benchmark performance.  This option can be specified more than
     /// once if to record multiple measurements.  If no measures are specified,
     /// the "cycles" measure will be used.
@@ -155,11 +156,73 @@ impl BenchmarkCommand {
             !self.engines.is_empty(),
             "must pass one or more engines to benchmark with -e/--engine"
         );
+        for (i, measure) in self.measures.iter().enumerate() {
+            // E.g. two callgrind measures would each toggle Callgrind's collection state,
+            // cancelling each other out.
+            anyhow::ensure!(
+                !self.measures[..i].contains(measure),
+                "`--measure {measure}` may only be specified once"
+            );
+        }
+        if let Some(wrapper_measure) = self.measures.iter().find(|m| m.needs_process_wrapper()) {
+            // E.g. cycle counts taken inside Callgrind's Valgrind wrapper would reflect the
+            // simulation, not the hardware.
+            anyhow::ensure!(
+                self.measures.len() == 1,
+                "`--measure {wrapper_measure}` cannot be combined with other measures: running \
+                 them under its Valgrind wrapper would distort their results"
+            );
+            #[cfg(target_os = "linux")]
+            anyhow::ensure!(
+                sightglass_recorder::measure::callgrind::valgrind_support().is_some(),
+                "this `sightglass-cli` was built without Valgrind support (the Valgrind headers \
+                 were not found at build time); install Valgrind and rebuild to use `--measure \
+                 {wrapper_measure}`"
+            );
+        }
 
-        if self.processes == 1 {
+        // Some measures (e.g. callgrind) require the benchmark process to run under an external
+        // tool; in that case run benchmarks in wrapped subprocesses, even with `--processes 1`,
+        // unless the user already launched us under the tool themselves.
+        if self.is_manually_wrapped() {
+            anyhow::ensure!(
+                self.processes == 1,
+                "a manually Valgrind-wrapped `sightglass-cli` must use `--processes 1`: Valgrind \
+                 does not follow the benchmark child processes that more than one process \
+                 requires; alternatively, drop the manual wrapper and `sightglass-cli` will \
+                 launch Valgrind around each benchmark process itself"
+            );
+        }
+
+        if self.processes == 1 && !self.spawn_under_process_wrapper() {
             self.execute_in_current_process()
         } else {
             self.execute_in_multiple_processes()
+        }
+    }
+
+    /// Does some selected measure require the benchmark process to run under an external tool,
+    /// and the user already launched this process under it themselves?
+    fn is_manually_wrapped(&self) -> bool {
+        let needs = self.measures.iter().any(MeasureType::needs_process_wrapper);
+        needs && Self::already_under_valgrind()
+    }
+
+    /// Must benchmark subprocesses be spawned under an external tool (see
+    /// [MeasureType::process_wrapper])?
+    fn spawn_under_process_wrapper(&self) -> bool {
+        let needs = self.measures.iter().any(MeasureType::needs_process_wrapper);
+        needs && !Self::already_under_valgrind()
+    }
+
+    fn already_under_valgrind() -> bool {
+        #[cfg(target_os = "linux")]
+        {
+            sightglass_recorder::measure::callgrind::running_under_valgrind()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            false
         }
     }
 
@@ -404,14 +467,21 @@ impl BenchmarkCommand {
         // Worklist that we randomly sample from.
         let mut choices = vec![];
 
-        for engine in &self.engines {
+        for (engine_index, engine) in self.engines.iter().enumerate() {
             // Ensure that each of our engines is built before we spawn any
             // child processes (potentially in a different working directory,
             // and therefore potentially invalidating relative paths used here).
             let engine = check_engine_path(engine)?;
 
+            // The `--name` override for this engine, if any.
+            let name = self
+                .names
+                .as_ref()
+                .and_then(|names| names.get(engine_index))
+                .cloned();
+
             for wasm in wasm_files.iter().cloned() {
-                choices.push((engine.clone(), wasm, self.processes));
+                choices.push((engine.clone(), name.clone(), wasm, self.processes));
             }
         }
 
@@ -422,11 +492,39 @@ impl BenchmarkCommand {
         let n = choices.len() * self.processes;
         let start = std::time::Instant::now();
 
+        // When a measure requires it (and the user did not already wrap us themselves), launch
+        // each benchmark subprocess under its external tool, telling the subprocess where the
+        // tool's output files will be written.
+        let process_wrapper = if self.spawn_under_process_wrapper() {
+            self.measures
+                .iter()
+                .find(|m| m.needs_process_wrapper())
+                .copied()
+        } else {
+            None
+        };
+
+        // An upper bound on how many per-phase measurements each subprocess will take (an
+        // external tool writes one output file per measurement): three phases per iteration,
+        // plus an eagerly compiled module when benchmarking a post-compilation phase.
+        let expected_dumps = u32::try_from(self.iterations_per_process)? * 3 + 1;
+
         while !choices.is_empty() {
             let index = rng.gen_range(0, choices.len());
-            let (engine, wasm, procs_left) = &mut choices[index];
+            let (engine, name, wasm, procs_left) = &mut choices[index];
 
-            let mut command = Command::new(&this_exe);
+            let wrapper = match process_wrapper {
+                Some(measure) => measure.process_wrapper(i, expected_dumps)?,
+                None => None,
+            };
+            let mut command = match wrapper {
+                Some((prefix, envs)) => {
+                    let mut command = Command::new(&prefix[0]);
+                    command.args(&prefix[1..]).arg(&this_exe).envs(envs);
+                    command
+                }
+                None => Command::new(&this_exe),
+            };
             command
                 .stdin(Stdio::null())
                 .stdout(Stdio::piped())
@@ -469,11 +567,23 @@ impl BenchmarkCommand {
                 command.arg(format!("--engine-flags={flags}"));
             }
 
+            if let Some(name) = name.as_ref() {
+                command.arg("--name").arg(name);
+            }
+
+            if let Some(working_dir) = &self.working_dir {
+                command.arg("--working-dir").arg(working_dir);
+            }
+
             command.arg("--").arg(&wasm);
 
-            let output = command
-                .output()
-                .context("failed to run benchmark subprocess")?;
+            let output = command.output().with_context(|| {
+                if process_wrapper.is_some() {
+                    "failed to run benchmark subprocess under valgrind (is valgrind installed?)"
+                } else {
+                    "failed to run benchmark subprocess"
+                }
+            })?;
 
             anyhow::ensure!(
                 output.status.success(),
@@ -513,10 +623,16 @@ impl BenchmarkCommand {
 
             // Parse the subprocess's output and add its measurements to our
             // accumulation.
-            measurements.extend(
+            let subprocess_measurements =
                 serde_json::from_slice::<Vec<Measurement<'_>>>(&output.stdout)
-                    .context("failed to read benchmark subprocess's results")?,
+                    .context("failed to read benchmark subprocess's results")?;
+            anyhow::ensure!(
+                !subprocess_measurements.is_empty()
+                    || !self.measures.iter().any(MeasureType::needs_process_wrapper),
+                "a benchmark subprocess recorded no measurements; if you wrapped `sightglass-cli` \
+                 in `valgrind` manually, note that Valgrind does not follow child processes."
             );
+            measurements.extend(subprocess_measurements);
 
             *procs_left -= 1;
             if *procs_left == 0 {

--- a/crates/cli/tests/all/benchmark.rs
+++ b/crates/cli/tests/all/benchmark.rs
@@ -151,6 +151,88 @@ fn benchmark_summary() {
         );
 }
 
+/// With the callgrind measure, `sightglass-cli` launches each benchmark process under Valgrind's
+/// Callgrind itself and records per-phase instruction counts. Without Valgrind installed, the run
+/// must fail loudly rather than silently record nothing.
+#[cfg(target_os = "linux")]
+#[test]
+fn benchmark_callgrind_measure_launches_valgrind() {
+    let have_valgrind = std::process::Command::new("valgrind")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false);
+
+    // Run in a temporary directory so that the Callgrind dump files do not
+    // litter the source tree; this requires an absolute benchmark path.
+    let noop = PathBuf::from(benchmark("noop")).canonicalize().unwrap();
+    let assert = sightglass_cli_benchmark()
+        .current_dir(std::env::temp_dir())
+        .arg("--raw")
+        .arg("--processes")
+        .arg("1")
+        .arg("--iterations-per-process")
+        .arg("1")
+        .arg("--measure")
+        .arg("callgrind")
+        .arg("--output-format")
+        .arg("csv")
+        .arg("--")
+        .arg(noop)
+        .assert();
+
+    if have_valgrind {
+        assert.success().stdout(
+            predicate::str::contains("Compilation,callgrind-ir")
+                .and(predicate::str::contains("Instantiation,callgrind-ir"))
+                .and(predicate::str::contains("Execution,callgrind-ir")),
+        );
+    } else {
+        // Either Valgrind's headers were missing when this binary was built ("built without
+        // Valgrind support") or the `valgrind` binary is missing now ("is valgrind installed?").
+        assert
+            .failure()
+            .stderr(predicate::str::is_match("(?i)valgrind").unwrap());
+    }
+}
+
+/// A wrapper-requiring measure cannot be combined with other measures: their results would be
+/// distorted by running under the Valgrind wrapper.
+#[cfg(target_os = "linux")]
+#[test]
+fn benchmark_rejects_callgrind_combined_with_other_measures() {
+    sightglass_cli_benchmark()
+        .arg("--measure")
+        .arg("callgrind")
+        .arg("--measure")
+        .arg("cycles")
+        .arg("--")
+        .arg(benchmark("noop"))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "cannot be combined with other measures",
+        ));
+}
+
+/// A duplicated measure is rejected: e.g. two callgrind measures would toggle Callgrind's
+/// collection state on and off again around each phase.
+#[test]
+fn benchmark_rejects_duplicate_measures() {
+    sightglass_cli_benchmark()
+        .arg("--measure")
+        .arg("cycles")
+        .arg("--measure")
+        .arg("cycles")
+        .arg("--")
+        .arg(benchmark("noop"))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "`--measure cycles` may only be specified once",
+        ));
+}
+
 #[test]
 #[cfg_attr(target_os = "windows", ignore)] // TODO: https://github.com/bytecodealliance/sightglass/issues/178
 fn benchmark_effect_size() -> anyhow::Result<()> {

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -499,6 +499,7 @@ impl<'a, 'de> Deserialize<'de> for EffectSize<'a> {
 /// - `./benchmarks/foo/benchmark.wasm` -> `foo`
 /// - `benchmarks/bar/benchmark.wasm` -> `bar`
 /// - `benchmarks/foo/bar.wasm` -> `foo/bar`
+/// - `benchmarks/foo/foo.wasm` -> `foo`
 /// - `simple.wasm` -> `simple`
 ///
 /// # Examples
@@ -509,6 +510,7 @@ impl<'a, 'de> Deserialize<'de> for EffectSize<'a> {
 /// assert_eq!(extract_benchmark_name("./benchmarks/foo/benchmark.wasm"), "foo");
 /// assert_eq!(extract_benchmark_name("benchmarks/bar/benchmark.wasm"), "bar");
 /// assert_eq!(extract_benchmark_name("benchmarks/foo/bar.wasm"), "foo/bar");
+/// assert_eq!(extract_benchmark_name("benchmarks/foo/foo.wasm"), "foo");
 /// assert_eq!(extract_benchmark_name("simple.wasm"), "simple");
 /// ```
 pub fn extract_benchmark_name(wasm_path: &str) -> String {
@@ -526,6 +528,14 @@ pub fn extract_benchmark_name(wasm_path: &str) -> String {
         path = stripped;
     } else if let Some(stripped) = path.strip_suffix(".wasm") {
         path = stripped;
+    }
+
+    // Collapse a benchmark file named after its directory (e.g.,
+    // `cm-online-stats/cm-online-stats.wasm`).
+    if let Some((dir, file)) = path.split_once('/') {
+        if dir == file {
+            path = dir;
+        }
     }
 
     path.to_string()

--- a/crates/recorder/Cargo.toml
+++ b/crates/recorder/Cargo.toml
@@ -21,6 +21,8 @@ ittapi = "0.3"
 perf-event = "0.4"
 # On supported platforms, we use libc's `sched_getcpu` to log the processor ID.
 libc = "0.2"
+# Used to delimit Sightglass phases when running under Valgrind's Callgrind.
+valgrind-requests = "1.1"
 
 # There are multiple implementations for pinning the benchmark to a single core.
 [target.'cfg(any(target_os="windows",target_os="macos",target_os="linux"))'.dependencies]

--- a/crates/recorder/src/measure/callgrind.rs
+++ b/crates/recorder/src/measure/callgrind.rs
@@ -1,0 +1,288 @@
+//! Measure each Sightglass phase using Valgrind's Callgrind. When this [Measure] is selected,
+//! `sightglass-cli` launches each benchmark process under `valgrind --tool=callgrind` itself (see
+//! [`command_prefix`]); collection is toggled on at the start of each phase and off at the end,
+//! and the statistics for each phase are dumped to a separate file annotated with the phase name
+//! (visible as the "trigger" in the dump's header):
+//!
+//! ```text
+//! sightglass-cli benchmark <path to>/benchmark.wasm \
+//!     --measure callgrind --processes 1 --iterations-per-process 1
+//! ```
+//!
+//! Each phase's event totals (e.g., `callgrind-ir` for instructions executed) are parsed from the
+//! dump files and recorded as measurements. The dump files themselves are left in place for deeper
+//! inspection with, e.g., KCachegrind.
+//!
+//! Running `sightglass-cli` under Valgrind manually is also supported (the launcher detects this
+//! and does not wrap again), in which case Callgrind's default output file naming is required to
+//! locate the dumps, so do not pass `--callgrind-out-file`, and use `--processes 1` (Valgrind does
+//! not follow child processes by default).
+//!
+//! Callgrind's instrumentation slows execution down considerably, but the instruction counts it
+//! measures are deterministic, so a single process and iteration is usually sufficient.
+
+use super::{Measure, Measurements};
+use anyhow::{anyhow, ensure, Context, Result};
+use sightglass_data::Phase;
+use std::ffi::{CString, OsString};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+use valgrind_requests::{callgrind, valgrind};
+
+/// The environment variable through which `sightglass-cli` tells a benchmark process it launched
+/// under Valgrind which `--callgrind-out-file` base path the dumps will be written to.
+pub const OUT_FILE_ENV: &str = "SIGHTGLASS_CALLGRIND_OUT_FILE";
+
+/// The number of dumps this process has written so far. Callgrind numbers a process' dump files
+/// with sequential part suffixes starting at `1`, regardless of which `CallgrindMeasure` instance
+/// requested the dump, so this counter must be process-global.
+static PARTS: AtomicU32 = AtomicU32::new(0);
+
+/// Was this binary built with Valgrind client-request support (i.e., were the Valgrind headers
+/// found at build time)? If so, is this process running under Valgrind?
+///
+/// `valgrind-requests` compiles its client requests to runtime aborts when the Valgrind headers
+/// are not found at build time, so probe it once under a panic guard (with the panic output
+/// suppressed) rather than crashing the harness.
+pub fn valgrind_support() -> Option<bool> {
+    static SUPPORT: std::sync::OnceLock<Option<bool>> = std::sync::OnceLock::new();
+    *SUPPORT.get_or_init(|| {
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let result = std::panic::catch_unwind(|| valgrind::running_on_valgrind() > 0).ok();
+        std::panic::set_hook(previous_hook);
+        result
+    })
+}
+
+/// Is this process running under Valgrind?
+pub fn running_under_valgrind() -> bool {
+    valgrind_support() == Some(true)
+}
+
+/// Prepare to launch the `spawn_index`th benchmark subprocess of a run under Callgrind, which
+/// will write `expected_dumps` per-phase dump files: choose the dump file base path, remove any
+/// stale dump files a previous run could have left at that path (reachable when the OS recycles
+/// this process id), and return the command prefix and environment variables with which to spawn
+/// the subprocess.
+pub fn process_wrapper(spawn_index: usize, expected_dumps: u32) -> Result<super::ProcessWrapper> {
+    let out_file = PathBuf::from(format!(
+        "callgrind.out.{}-{spawn_index}",
+        std::process::id()
+    ));
+    remove_stale_dumps(&out_file, expected_dumps)?;
+    Ok((
+        command_prefix(&out_file),
+        vec![(OUT_FILE_ENV, out_file.into())],
+    ))
+}
+
+/// The command prefix with which to launch a benchmark process under Callgrind, writing its dumps
+/// to `out_file` (and `out_file.<n>`, one per phase measurement).
+fn command_prefix(out_file: &Path) -> Vec<OsString> {
+    let mut out_file_flag = OsString::from("--callgrind-out-file=");
+    out_file_flag.push(out_file);
+    vec![
+        "valgrind".into(),
+        "--quiet".into(),
+        "--tool=callgrind".into(),
+        // Callgrind only collects between this measure's start/end toggles.
+        "--collect-atstart=no".into(),
+        // Without cache and branch simulation, Callgrind just counts instructions, which is both
+        // faster and deterministic.
+        "--cache-sim=no".into(),
+        "--branch-sim=no".into(),
+        out_file_flag,
+        "--".into(),
+    ]
+}
+
+/// The dump file Callgrind writes for the `part`th `DUMP_STATS` of a process writing to the
+/// `--callgrind-out-file` base path `base`.
+fn dump_file(base: &Path, part: u32) -> PathBuf {
+    let mut path = base.to_path_buf().into_os_string();
+    path.push(format!(".{part}"));
+    path.into()
+}
+
+/// Remove the dump files a previous run could have written to the `out_file` base path: the base
+/// file (Callgrind's final dump at process exit) plus the `expected_dumps` per-phase part files.
+fn remove_stale_dumps(out_file: &Path, expected_dumps: u32) -> Result<()> {
+    let paths = std::iter::once(out_file.to_path_buf())
+        .chain((1..=expected_dumps).map(|part| dump_file(out_file, part)));
+    for path in paths {
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).context(format!(
+                    "unable to remove the stale dump file `{}`",
+                    path.display()
+                ))
+            }
+        }
+    }
+    Ok(())
+}
+
+pub struct CallgrindMeasure {
+    /// Whether this process is running under Valgrind; the client requests are no-ops (and no dump
+    /// files are written) otherwise.
+    under_valgrind: bool,
+    /// The `--callgrind-out-file` base path communicated by the parent `sightglass-cli` process
+    /// via [OUT_FILE_ENV], if any; otherwise dumps are located by Callgrind's default
+    /// `callgrind.out.<pid>` naming.
+    out_file: Option<PathBuf>,
+}
+
+impl Default for CallgrindMeasure {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CallgrindMeasure {
+    pub fn new() -> Self {
+        assert!(
+            valgrind_support().is_some(),
+            "this binary was built without Valgrind support (the Valgrind headers were not found \
+             at build time); install Valgrind and rebuild"
+        );
+        let under_valgrind = running_under_valgrind();
+        let out_file = std::env::var_os(OUT_FILE_ENV).map(PathBuf::from);
+        assert!(
+            out_file.is_none() || under_valgrind,
+            "sightglass-cli launched this benchmark process under Valgrind ({OUT_FILE_ENV} is \
+             set) but the process is not running under Valgrind"
+        );
+        if !under_valgrind {
+            log::warn!(
+                "the callgrind measure is enabled but this process is not running under Valgrind, \
+                 so no instruction counts will be recorded"
+            );
+        }
+        Self {
+            under_valgrind,
+            out_file,
+        }
+    }
+
+    /// The dump file Callgrind writes for the `part`th `DUMP_STATS` of this process.
+    fn dump_path(&self, part: u32) -> PathBuf {
+        match &self.out_file {
+            Some(base) => dump_file(base, part),
+            None => PathBuf::from(format!("callgrind.out.{}.{}", std::process::id(), part)),
+        }
+    }
+}
+
+impl Measure for CallgrindMeasure {
+    fn start(&mut self, _phase: Phase) {
+        callgrind::zero_stats();
+        callgrind::toggle_collect();
+    }
+
+    fn end(&mut self, phase: Phase, measurements: &mut Measurements) {
+        callgrind::toggle_collect();
+        let reason = CString::new(phase.to_string()).expect("phase names do not contain nul bytes");
+        callgrind::dump_stats_at(reason);
+
+        if !self.under_valgrind {
+            return;
+        }
+
+        // `DUMP_STATS` is synchronous, so the dump file is complete once `dump_stats_at` returns.
+        let part = PARTS.fetch_add(1, Ordering::SeqCst) + 1;
+        let path = self.dump_path(part);
+        // Per the `Measure` contract, a broken measurement mechanism is a panic, not a silently
+        // emptier result set.
+        let events = parse_dump_summary(&path).unwrap_or_else(|error| {
+            panic!(
+                "unable to record callgrind measurements from the dump file `{}`{}: {:#}",
+                path.display(),
+                if self.out_file.is_none() {
+                    " (was `--callgrind-out-file` or another dump-affecting option passed to \
+                     valgrind?)"
+                } else {
+                    ""
+                },
+                error
+            )
+        });
+        for (event, count) in events {
+            measurements.add(
+                phase,
+                format!("callgrind-{}", event.to_lowercase()).into(),
+                count,
+            );
+        }
+    }
+}
+
+/// Parse the `summary:` totals of a Callgrind dump file, returning each recorded event (named by
+/// the dump's `events:` header, e.g. `Ir`) and its total count.
+fn parse_dump_summary(path: &Path) -> Result<Vec<(String, u64)>> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("unable to read `{}`", path.display()))?;
+    parse_summary(&contents)
+}
+
+fn parse_summary(contents: &str) -> Result<Vec<(String, u64)>> {
+    let mut events: Option<Vec<&str>> = None;
+    for line in contents.lines() {
+        if let Some(rest) = line.strip_prefix("events:") {
+            events = Some(rest.split_whitespace().collect());
+        } else if let Some(rest) = line.strip_prefix("summary:") {
+            let events = events.ok_or_else(|| anyhow!("missing an `events:` header line"))?;
+            let counts = rest
+                .split_whitespace()
+                .map(|v| v.parse::<u64>().context("invalid `summary:` count"))
+                .collect::<Result<Vec<_>>>()?;
+            ensure!(
+                events.len() == counts.len(),
+                "the `events:` header names {} events but the `summary:` line has {} counts",
+                events.len(),
+                counts.len()
+            );
+            return Ok(events.into_iter().map(str::to_string).zip(counts).collect());
+        }
+    }
+    Err(anyhow!("missing a `summary:` line"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_summary;
+
+    #[test]
+    fn parse_single_event_summary() {
+        let dump = "# callgrind format\nversion: 1\ncreator: callgrind-3.24.0\npid: 36\n\
+                    desc: Trigger: Client Request: execution\nevents: Ir\n\
+                    fn=(1) main\n1 42\n\nsummary: 160763380\n";
+        assert_eq!(
+            parse_summary(dump).unwrap(),
+            vec![("Ir".to_string(), 160763380)]
+        );
+    }
+
+    #[test]
+    fn parse_multi_event_summary() {
+        let dump = "events: Ir Dr Dw I1mr\nsummary: 100 200 300 400\n";
+        assert_eq!(
+            parse_summary(dump).unwrap(),
+            vec![
+                ("Ir".to_string(), 100),
+                ("Dr".to_string(), 200),
+                ("Dw".to_string(), 300),
+                ("I1mr".to_string(), 400),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_errors() {
+        assert!(parse_summary("").is_err());
+        assert!(parse_summary("summary: 1 2 3\n").is_err());
+        assert!(parse_summary("events: Ir\nsummary: 1 2\n").is_err());
+    }
+}

--- a/crates/recorder/src/measure/mod.rs
+++ b/crates/recorder/src/measure/mod.rs
@@ -78,6 +78,8 @@ pub trait Measure: 'static {
 }
 
 #[cfg(target_os = "linux")]
+pub mod callgrind;
+#[cfg(target_os = "linux")]
 pub mod counters;
 #[cfg(target_os = "linux")]
 pub mod insts;
@@ -95,7 +97,7 @@ pub mod vtune;
 /// let ty: MeasureType = "noop".parse().unwrap();
 /// let measure = ty.build();
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MeasureType {
     /// No measurement.
     Noop,
@@ -116,6 +118,10 @@ pub enum MeasureType {
     /// Measure instructions retired.
     #[cfg(target_os = "linux")]
     InstsRetired,
+
+    /// Measure instruction totals with Callgrind.
+    #[cfg(target_os = "linux")]
+    Callgrind,
 }
 
 impl fmt::Display for MeasureType {
@@ -129,6 +135,8 @@ impl fmt::Display for MeasureType {
             MeasureType::PerfCounters => write!(f, "perf-counters"),
             #[cfg(target_os = "linux")]
             MeasureType::InstsRetired => write!(f, "insts-retired"),
+            #[cfg(target_os = "linux")]
+            MeasureType::Callgrind => write!(f, "callgrind"),
         }
     }
 }
@@ -145,12 +153,51 @@ impl FromStr for MeasureType {
             "perf-counters" => Ok(Self::PerfCounters),
             #[cfg(target_os = "linux")]
             "insts-retired" => Ok(Self::InstsRetired),
+            #[cfg(target_os = "linux")]
+            "callgrind" => Ok(Self::Callgrind),
             _ => Err("unknown measure type"),
         }
     }
 }
 
+/// A command prefix and the environment variables with which to launch a benchmark process under
+/// an external tool; see [MeasureType::process_wrapper].
+pub type ProcessWrapper = (
+    Vec<std::ffi::OsString>,
+    Vec<(&'static str, std::ffi::OsString)>,
+);
+
 impl MeasureType {
+    /// Does this measure require the benchmark process to be launched under an external tool (see
+    /// [Self::process_wrapper])?
+    pub fn needs_process_wrapper(&self) -> bool {
+        #[cfg(target_os = "linux")]
+        {
+            matches!(self, Self::Callgrind)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            false
+        }
+    }
+
+    /// If this measure requires the benchmark process to run under an external tool, prepare to
+    /// launch the `spawn_index`th benchmark subprocess of this run. It will take
+    /// `expected_dumps` per-phase measurements and return the command prefix with which to
+    /// launch it and the environment variables to pass to it.
+    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+    pub fn process_wrapper(
+        &self,
+        spawn_index: usize,
+        expected_dumps: u32,
+    ) -> anyhow::Result<Option<ProcessWrapper>> {
+        match self {
+            #[cfg(target_os = "linux")]
+            Self::Callgrind => callgrind::process_wrapper(spawn_index, expected_dumps).map(Some),
+            _ => Ok(None),
+        }
+    }
+
     /// Build a dynamic instance of a [Measure]. The recording infrastructure does not need to know
     /// exactly what type of [Measure] we want to use, just that it can `start` and `end`
     /// measurements.
@@ -164,6 +211,8 @@ impl MeasureType {
             Self::PerfCounters => Box::new(counters::CounterMeasure::new()),
             #[cfg(target_os = "linux")]
             Self::InstsRetired => Box::new(insts::InstsRetiredMeasure::new()),
+            #[cfg(target_os = "linux")]
+            Self::Callgrind => Box::new(callgrind::CallgrindMeasure::new()),
         }
     }
 }


### PR DESCRIPTION
Add CallgrindMeasure and a concept of process wrapping to benchmarks so that
each CallgrindMeasure is run under valgrind.

Additionally adds a gh workflow that runs the new callgrind measure nightly and on pushes to main.
