### PR TITLE
Error when benchmark `--output-format` is passed without `--raw`

### DIFF
--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -269,7 +269,12 @@ pub struct BenchmarkCommand {
 
     /// The format of the raw output data when `--raw` is used. Either 'json' or
     /// 'csv'.
-    #[arg(short = 'f', long = "output-format", default_value = "json")]
+    #[arg(
+        short = 'f',
+        long = "output-format",
+        default_value = "json",
+        requires = "raw"
+    )]
     output_format: Format,
 
     /// Path to a file which will contain the output data, or nothing to print

--- a/crates/cli/tests/all/benchmark.rs
+++ b/crates/cli/tests/all/benchmark.rs
@@ -4,6 +4,16 @@ use predicates::prelude::*;
 use sightglass_data::Measurement;
 use std::path::PathBuf;
 use tempfile::TempDir;
+
+#[test]
+fn benchmark_output_format_requires_raw() {
+    sightglass_cli()
+        .args(["benchmark", "--output-format", "csv", "dummy.wasm"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--raw"));
+}
+
 #[test]
 fn benchmark_phase_compilation() {
     sightglass_cli_benchmark()


### PR DESCRIPTION
The `-f`/`--output-format` flag only affects raw output, so passing it without `--raw` doesn't make sense.