### PR TITLE
Compute "Sum Total" measurements across benchmarks

### DIFF
--- a/crates/analysis/src/effect_size.rs
+++ b/crates/analysis/src/effect_size.rs
@@ -45,8 +45,13 @@ pub fn calculate<'a>(
     for key in keys {
         let key_measurements: Vec<_> = measurements.iter().filter(|m| key.matches(m)).collect();
 
-        let mut engines: Vec<_> = key_measurements.iter().map(|m| &m.engine).collect();
-        engines.sort();
+        let engines: Vec<_> = key_measurements
+            .iter()
+            .map(|m| &m.engine)
+            // Deduplicate. Use a `BTreeSet` to keep them sorted.
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
 
         // Create an `EffectSize` comparing each pair of distinct engines within
         // this group of measurements.
@@ -92,14 +97,18 @@ pub fn write(
     significance_level: f64,
     output_file: &mut dyn Write,
 ) -> Result<()> {
-    // Sort the effect sizes so that we focus on statistically significant results before
-    // insignificant results and larger relative effect sizes before smaller relative effect sizes.
+    // Sort the effect sizes so that our "Sum Total" results come first, then we
+    // focus on statistically significant results before insignificant results
+    // and larger relative effect sizes before smaller relative effect sizes.
     effect_sizes.sort_by(|x, y| {
-        y.is_significant().cmp(&x.is_significant()).then_with(|| {
-            let x_speedup = x.a_speed_up_over_b().0.max(x.b_speed_up_over_a().0);
-            let y_speedup = y.a_speed_up_over_b().0.max(y.b_speed_up_over_a().0);
-            y_speedup.partial_cmp(&x_speedup).unwrap()
-        })
+        (y.wasm == "Sum Total")
+            .cmp(&(x.wasm == "Sum Total"))
+            .then_with(|| y.is_significant().cmp(&x.is_significant()))
+            .then_with(|| {
+                let x_speedup = x.a_speed_up_over_b().0.max(x.b_speed_up_over_a().0);
+                let y_speedup = y.a_speed_up_over_b().0.max(y.b_speed_up_over_a().0);
+                y_speedup.partial_cmp(&x_speedup).unwrap()
+            })
     });
 
     for effect_size in effect_sizes {
@@ -252,5 +261,59 @@ mod tests {
     fn effect_size_requires_at_least_two_engines() {
         let measurements = vec![measurement("only", 1), measurement("only", 2)];
         assert!(calculate(0.01, &measurements).is_err());
+    }
+
+    #[test]
+    fn write_sorts_sum_total_first() -> Result<()> {
+        fn pair<'a>(wasm: &'a str) -> (EffectSize<'a>, Vec<Summary<'a>>) {
+            let a = Engine {
+                name: "a".into(),
+                flags: None,
+            };
+            let b = Engine {
+                name: "b".into(),
+                flags: None,
+            };
+            let effect_size = EffectSize {
+                arch: "x86".into(),
+                wasm: wasm.into(),
+                phase: Phase::Execution,
+                event: "cycles".into(),
+                a_engine: a.clone(),
+                a_mean: 100.0,
+                b_engine: b.clone(),
+                b_mean: 200.0,
+                significance_level: 0.01,
+                half_width_confidence_interval: 1.0,
+            };
+            let summary = |engine: Engine<'a>, mean: f64| Summary {
+                arch: "x86".into(),
+                engine,
+                wasm: wasm.into(),
+                phase: Phase::Execution,
+                event: "cycles".into(),
+                min: mean as u64,
+                max: mean as u64,
+                median: mean as u64,
+                mean,
+                mean_deviation: 0.0,
+            };
+            (effect_size, vec![summary(a, 100.0), summary(b, 200.0)])
+        }
+
+        // "Aaa" sorts before "Sum Total" and is passed first, so this exercises
+        // the explicit total-first ordering rather than a sorting accident.
+        let (es_aaa, mut summaries) = pair("Aaa");
+        let (es_total, mut total_summaries) = pair("Sum Total");
+        summaries.append(&mut total_summaries);
+
+        let mut out = vec![];
+        write(vec![es_aaa, es_total], &summaries, 0.01, &mut out)?;
+        let out = String::from_utf8(out)?;
+
+        let total = out.find("Sum Total").unwrap();
+        let aaa = out.find("Aaa").unwrap();
+        assert!(total < aaa, "Sum Total should be first:\n{out}");
+        Ok(())
     }
 }

--- a/crates/analysis/src/effect_size.rs
+++ b/crates/analysis/src/effect_size.rs
@@ -3,15 +3,18 @@ use anyhow::Result;
 use sightglass_data::{EffectSize, Engine, Measurement, Phase, Summary};
 use std::{collections::BTreeSet, io::Write};
 
-/// Find the effect size (and confidence interval) of between two different
-/// engines (i.e. two different commits of Wasmtime).
+/// Find the effect size (and confidence interval) between different engines
+/// (i.e. different commits of Wasmtime).
 ///
 /// This allows us to justify statements like "we are 99% confident that the new
 /// register allocator is 13.6% faster (± 1.7%) than the old register
 /// allocator."
 ///
-/// This can only test differences between the results for exactly two different
-/// engines. If there aren't exactly two different engines represented in
+/// The `measurements` must contain results for two or more different engines.
+/// Each returned [`EffectSize`] compares exactly two different engines: for
+/// every group of measurements that share an architecture, benchmark, phase,
+/// and event, one `EffectSize` is produced for each pair of engines present in
+/// that group. If fewer than two different engines are represented in
 /// `measurements` then an error is returned.
 pub fn calculate<'a>(
     significance_level: f64,
@@ -24,52 +27,58 @@ pub fn calculate<'a>(
              Found {significance_level}."
     );
 
+    // We need at least two different engines to have anything to compare.
+    let all_engines: BTreeSet<_> = measurements.iter().map(|m| &m.engine).collect();
+    anyhow::ensure!(
+        all_engines.len() >= 2,
+        "Comparing effect sizes requires two or more different engines. Found {} \
+             different engines.",
+        all_engines.len()
+    );
+
     let keys = KeyBuilder::all()
         .engine(false)
         .engine_flags(false)
         .keys(measurements);
-    let mut results = Vec::with_capacity(keys.len());
+    let mut results = Vec::new();
 
     for key in keys {
         let key_measurements: Vec<_> = measurements.iter().filter(|m| key.matches(m)).collect();
 
-        // NB: `BTreeSet` so they're always sorted.
-        let engines: BTreeSet<_> = key_measurements.iter().map(|m| &m.engine).collect();
-        anyhow::ensure!(
-            engines.len() == 2,
-            "Can only test significance between exactly two different engines. Found {} \
-                 different engines.",
-            engines.len()
-        );
+        let mut engines: Vec<_> = key_measurements.iter().map(|m| &m.engine).collect();
+        engines.sort();
 
-        let mut engines = engines.into_iter();
-        let engine_a = engines.next().unwrap();
-        let engine_b = engines.next().unwrap();
+        // Create an `EffectSize` comparing each pair of distinct engines within
+        // this group of measurements.
+        for (i, engine_a) in engines.iter().enumerate() {
+            for engine_b in &engines[i + 1..] {
+                let a: behrens_fisher::Stats = key_measurements
+                    .iter()
+                    .filter(|m| &m.engine == *engine_a)
+                    .map(|m| m.count as f64)
+                    .collect();
+                let b: behrens_fisher::Stats = key_measurements
+                    .iter()
+                    .filter(|m| &m.engine == *engine_b)
+                    .map(|m| m.count as f64)
+                    .collect();
 
-        let a: behrens_fisher::Stats = key_measurements
-            .iter()
-            .filter(|m| &m.engine == engine_a)
-            .map(|m| m.count as f64)
-            .collect();
-        let b: behrens_fisher::Stats = key_measurements
-            .iter()
-            .filter(|m| &m.engine == engine_b)
-            .map(|m| m.count as f64)
-            .collect();
-
-        let ci = behrens_fisher::confidence_interval(1.0 - significance_level, a, b).unwrap_or(0.0);
-        results.push(EffectSize {
-            arch: key.arch.unwrap(),
-            wasm: key.wasm.unwrap(),
-            phase: key.phase.unwrap(),
-            event: key.event.unwrap(),
-            a_engine: engine_a.clone(),
-            a_mean: a.mean,
-            b_engine: engine_b.clone(),
-            b_mean: b.mean,
-            significance_level,
-            half_width_confidence_interval: ci,
-        });
+                let ci = behrens_fisher::confidence_interval(1.0 - significance_level, a, b)
+                    .unwrap_or(0.0);
+                results.push(EffectSize {
+                    arch: key.arch.clone().unwrap(),
+                    wasm: key.wasm.clone().unwrap(),
+                    phase: key.phase.unwrap(),
+                    event: key.event.clone().unwrap(),
+                    a_engine: (*engine_a).clone(),
+                    a_mean: a.mean,
+                    b_engine: (*engine_b).clone(),
+                    b_mean: b.mean,
+                    significance_level,
+                    half_width_confidence_interval: ci,
+                });
+            }
+        }
     }
 
     Ok(results)
@@ -181,4 +190,67 @@ pub fn write(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn measurement<'a>(engine: &'a str, count: u64) -> Measurement<'a> {
+        Measurement {
+            arch: "x86_64".into(),
+            engine: Engine {
+                name: engine.into(),
+                flags: None,
+            },
+            wasm: "bench.wasm".into(),
+            process: 0,
+            iteration: 0,
+            phase: Phase::Execution,
+            event: "cycles".into(),
+            count,
+        }
+    }
+
+    #[test]
+    fn effect_size_for_each_pair_of_engines() -> Result<()> {
+        // Three engines within a single (arch, wasm, phase, event) group should
+        // yield one `EffectSize` per unordered pair of engines: (a, b), (a, c),
+        // and (b, c).
+        let mut measurements = vec![];
+        for (engine, base) in [("a", 100), ("b", 200), ("c", 300)] {
+            for i in 0..5 {
+                measurements.push(measurement(engine, base + i));
+            }
+        }
+
+        let effect_sizes = calculate(0.01, &measurements)?;
+        assert_eq!(effect_sizes.len(), 3);
+
+        let pairs: Vec<(String, String)> = effect_sizes
+            .iter()
+            .map(|e| (e.a_engine.name.to_string(), e.b_engine.name.to_string()))
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![
+                ("a".to_string(), "b".to_string()),
+                ("a".to_string(), "c".to_string()),
+                ("b".to_string(), "c".to_string()),
+            ]
+        );
+
+        // Every `EffectSize` compares two *different* engines.
+        for e in &effect_sizes {
+            assert_ne!(e.a_engine, e.b_engine);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn effect_size_requires_at_least_two_engines() {
+        let measurements = vec![measurement("only", 1), measurement("only", 2)];
+        assert!(calculate(0.01, &measurements).is_err());
+    }
 }

--- a/crates/analysis/src/summarize.rs
+++ b/crates/analysis/src/summarize.rs
@@ -106,11 +106,15 @@ fn median(numbers: &mut [u64]) -> u64 {
 
 /// Write a vector of [Summary] structures to the passed `output_file` in human-readable form.
 pub fn write(mut summaries: Vec<Summary<'_>>, output_file: &mut dyn Write) -> Result<()> {
-    // TODO this sorting is not using `arch` which is not guaranteed to be the same in result sets;
-    // potentially this could re-use `Key` functionality.
+    // TODO this sorting is not using `arch` which is not guaranteed to be the
+    // same in result sets; potentially this could re-use `Key` functionality.
+    //
+    // Our "Sum Total" results always come first, then we sort by phase,
+    // benchmark, event, and finally engine.
     summaries.sort_by(|x, y| {
-        x.phase
-            .cmp(&y.phase)
+        (y.wasm == "Sum Total")
+            .cmp(&(x.wasm == "Sum Total"))
+            .then_with(|| x.phase.cmp(&y.phase))
             .then_with(|| x.wasm.cmp(&y.wasm))
             .then_with(|| x.event.cmp(&y.event))
             .then_with(|| x.engine.cmp(&y.engine))
@@ -237,6 +241,39 @@ mod tests {
         ];
 
         assert_eq!(calculate(&measurements).len(), 3);
+    }
+
+    #[test]
+    fn write_sorts_sum_total_first() {
+        fn summary<'a>(wasm: &'a str) -> Summary<'a> {
+            Summary {
+                arch: "x86".into(),
+                engine: "e".into(),
+                wasm: wasm.into(),
+                phase: Phase::Compilation,
+                event: "cycles".into(),
+                min: 1,
+                max: 3,
+                median: 2,
+                mean: 2.0,
+                mean_deviation: 0.0,
+            }
+        }
+
+        // "Aaa" sorts before "Sum Total" lexicographically, so this exercises
+        // the explicit total-first ordering rather than a sorting accident.
+        let summaries = vec![summary("Aaa"), summary("Sum Total"), summary("zzz")];
+        let mut out = vec![];
+        write(summaries, &mut out).unwrap();
+        let out = String::from_utf8(out).unwrap();
+
+        let total = out.find("Sum Total").unwrap();
+        let aaa = out.find("Aaa").unwrap();
+        let zzz = out.find("zzz").unwrap();
+        assert!(
+            total < aaa && total < zzz,
+            "Sum Total should be first:\n{out}"
+        );
     }
 
     #[test]

--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -747,10 +747,18 @@ impl BenchmarkCommand {
     ) -> Result<()> {
         if self.raw {
             self.output_format.write(measurements, output_file)?;
-        } else if self.engines.len() == 2 {
-            display_effect_size(measurements, self.significance_level, output_file)?;
         } else {
-            display_summaries(measurements, output_file)?;
+            // Augment the measurements with "Sum Total" measurements that sum
+            // each sample's counts across all benchmarks, so that the analysis
+            // reports totals in addition to per-benchmark results.
+            let mut measurements = measurements.to_vec();
+            measurements.extend(sum_totals(&measurements));
+
+            if self.engines.len() == 2 {
+                display_effect_size(&measurements, self.significance_level, output_file)?;
+            } else {
+                display_summaries(&measurements, output_file)?;
+            }
         }
         Ok(())
     }
@@ -878,6 +886,67 @@ fn display_summaries(measurements: &[Measurement<'_>], output_file: &mut dyn Wri
     sightglass_analysis::summarize::write(summaries, output_file)
 }
 
+/// Sum measurement `count`s across all benchmarks for each iteration, producing
+/// new "Sum Total" measurements.
+///
+/// That is, if the given measurements have 50 unique samples for each
+/// benchmark, then this will add 50 "Sum Total" measurements, each of which is
+/// the sum of, e.g., instructions retired when compiling all benchmarks on
+/// their `i`th sample.
+///
+/// This is useful because (a) it gives us a single "top line" number for the
+/// whole benchmark run, and (b) on noisy machines with high variance it can
+/// (often) be the case that any individual benchmark doesn't show statistically
+/// significant differences between two engines but the sum totals *do* show
+/// statistically significant differences due to effetively having a greater
+/// number of samples.
+fn sum_totals<'a>(measurements: &[Measurement<'a>]) -> Vec<Measurement<'a>> {
+    use std::borrow::Cow;
+    use std::collections::BTreeMap;
+
+    // Key by every field except `wasm` and `count`: (arch, engine, process,
+    // iteration, phase, event).
+    let mut totals: BTreeMap<
+        (
+            Cow<'a, str>,
+            sightglass_data::Engine<'a>,
+            u32,
+            u32,
+            Phase,
+            Cow<'a, str>,
+        ),
+        u64,
+    > = BTreeMap::new();
+
+    for m in measurements {
+        let key = (
+            m.arch.clone(),
+            m.engine.clone(),
+            m.process,
+            m.iteration,
+            m.phase,
+            m.event.clone(),
+        );
+        *totals.entry(key).or_insert(0) += m.count;
+    }
+
+    totals
+        .into_iter()
+        .map(
+            |((arch, engine, process, iteration, phase, event), count)| Measurement {
+                arch,
+                engine,
+                wasm: "Sum Total".into(),
+                process,
+                iteration,
+                phase,
+                event,
+                count,
+            },
+        )
+        .collect()
+}
+
 // Check that a passed engine path is indeed a valid path; the returned value is a path to the built
 // engine's dylib.
 pub fn check_engine_path(engine: &str) -> Result<PathBuf> {
@@ -923,6 +992,45 @@ fn compare_output_file(wasm: &Path, actual: &Path, expected: &Path) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sum_totals_sums_counts_across_benchmarks() {
+        let m = |wasm: &'static str, iteration: u32, count: u64| Measurement {
+            arch: "x86_64".into(),
+            engine: sightglass_data::Engine {
+                name: "e".into(),
+                flags: None,
+            },
+            wasm: wasm.into(),
+            process: 7,
+            iteration,
+            phase: Phase::Execution,
+            event: "cycles".into(),
+            count,
+        };
+
+        // Two benchmarks measured over two iterations, sharing every other
+        // field. Each (process, iteration) sample is summed across benchmarks.
+        let measurements = vec![
+            m("a.wasm", 0, 10),
+            m("b.wasm", 0, 100),
+            m("a.wasm", 1, 20),
+            m("b.wasm", 1, 200),
+        ];
+
+        let totals = sum_totals(&measurements);
+        assert_eq!(totals.len(), 2);
+        for t in &totals {
+            assert_eq!(t.wasm, "Sum Total");
+            assert_eq!(t.process, 7);
+            assert_eq!(t.phase, Phase::Execution);
+            assert_eq!(t.event, "cycles");
+        }
+
+        let mut by_iteration: Vec<_> = totals.iter().map(|t| (t.iteration, t.count)).collect();
+        by_iteration.sort();
+        assert_eq!(by_iteration, vec![(0, 110), (1, 220)]);
+    }
 
     #[test]
     fn test_display_summaries() -> Result<()> {

--- a/crates/cli/tests/all/benchmark.rs
+++ b/crates/cli/tests/all/benchmark.rs
@@ -205,6 +205,24 @@ fn benchmark_effect_size() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// With multiple benchmarks and non-raw (summary) output, a "Sum Total" row is
+/// added that sums each sample's counts across the benchmarks. Using a single
+/// process makes the per-sample sums span both benchmarks.
+#[test]
+fn benchmark_sum_total() {
+    sightglass_cli_benchmark()
+        .arg("--processes")
+        .arg("1")
+        .arg("--iterations-per-process")
+        .arg("2")
+        .arg("--")
+        .arg(benchmark("noop"))
+        .arg(benchmark("pulldown-cmark"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Sum Total"));
+}
+
 /// --output-file writes raw JSON to a file rather than stdout.
 #[test]
 fn benchmark_output_file() -> anyhow::Result<()> {


### PR DESCRIPTION
Depends on https://github.com/bytecodealliance/sightglass/pull/324 (which is the first commit)

When not writing raw results, sum each sample's count across all benchmarks into new "Sum Total" measurements. The `{summarize,effect_size}::write` functions always sort these totals first.

Example `effect_size` output:

```
compilation :: cycles :: Sum Total

  No difference in performance.

  [42440 2078805.99 22345522] bar.dylib
  [42143 2118448.96 21992615] foo.dylib

compilation :: cycles :: benchmarks/rust-protobuf/benchmark.wasm

  No difference in performance.

  [254047 263161.00 276396] bar.dylib
  [278563 310704.33 339043] foo.dylib

compilation :: cycles :: benchmarks/libsodium/libsodium-onetimeauth7.wasm

  No difference in performance.

  [313024 335259.00 362670] bar.dylib
  [284558 291442.33 299564] foo.dylib

...
```

Example `summary` output:

```
compilation
  Sum Total
    cycles
      [43667 2067328.82 21894814] /Users/n.fitzgerald/scratch/sightglass-analysis-tweaks/engines/wasmtime/libengine.dylib
  benchmarks/blake3-scalar/benchmark.wasm
    cycles
      [202798 215967.20 224731] /Users/n.fitzgerald/scratch/sightglass-analysis-tweaks/engines/wasmtime/libengine.dylib
  benchmarks/bz2/benchmark.wasm
    cycles
      [410880 441370.60 496848] /Users/n.fitzgerald/scratch/sightglass-analysis-tweaks/engines/wasmtime/libengine.dylib
  benchmarks/cm-online-stats/cm-online-stats.wasm
    cycles
      [65024 68305.20 70651] /Users/n.fitzgerald/scratch/sightglass-analysis-tweaks/engines/wasmtime/libengine.dylib
...
```
