### PR TITLE
Allow engine flags to be specified multiple times

### DIFF
--- a/benchmarks/Dockerfile.rust
+++ b/benchmarks/Dockerfile.rust
@@ -1,4 +1,4 @@
-FROM rust:1.87
+FROM rust:1.96
 RUN rustup target add wasm32-wasip1
 # Install protobuf compiler for rust-protobuf benchmark
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*

--- a/benchmarks/tract-onnx-image-classification/Dockerfile
+++ b/benchmarks/tract-onnx-image-classification/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.88
+FROM rust:1.96
 RUN rustup target add wasm32-wasip1
 WORKDIR /usr/src
 ADD rust-benchmark rust-benchmark

--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -65,7 +65,7 @@ mod callgrind {
             }
         }
 
-        pub(super) fn validate(&self) -> Result<()> {
+        pub(super) fn validate_callgrind(&self) -> Result<()> {
             if self.uses_callgrind() && self.measures.len() > 1 {
                 anyhow::bail!(
                     "callgrind must be used by itself and cannot be combined with other measures"
@@ -83,6 +83,7 @@ mod callgrind {
             &self,
             this_exe: &Path,
             engine: &Path,
+            engine_flags: Option<&str>,
             wasm: &Path,
         ) -> Result<PreparedCommand> {
             ensure_tools_available()?;
@@ -122,6 +123,7 @@ mod callgrind {
             self.add_benchmark_child_args(
                 &mut prepared.command,
                 engine,
+                engine_flags,
                 wasm,
                 1,
                 self.iterations_per_process(),
@@ -182,7 +184,7 @@ mod callgrind {
             DEFAULT_ITERATIONS_PER_PROCESS
         }
 
-        pub(super) fn validate(&self) -> Result<()> {
+        pub(super) fn validate_callgrind(&self) -> Result<()> {
             Ok(())
         }
 
@@ -194,6 +196,7 @@ mod callgrind {
             &self,
             _this_exe: &Path,
             _engine: &Path,
+            _engine_flags: Option<&str>,
             _wasm: &Path,
         ) -> Result<PreparedCommand> {
             unreachable!()
@@ -229,14 +232,55 @@ pub struct BenchmarkCommand {
     #[arg(long = "engine", short = 'e', value_name = "PATH")]
     engines: Vec<String>,
 
-    /// Configure an engine using engine-specific flags. (For the Wasmtime
-    /// engine, these can be a subset of flags from `wasmtime run --help`).
+    /// Configure the engine(s) using engine-specific flags.
+    ///
+    /// For a Wasmtime-based engine, for example, these can be a subset of flags
+    /// from `wasmtime run --help`.
+    ///
+    /// This may be passed multiple times and is paired with the engines
+    /// (`-e`/`--engine`) as follows:
+    ///
+    /// - If there is a single engine and more than one set of `--engine-flags`,
+    ///   then that engine is paired with each set of flags.
+    ///
+    /// - Otherwise, if the number of `--engine-flags` equals the number of
+    ///   engines, then each engine is paired with the flags in the same
+    ///   position.
+    ///
+    /// - Otherwise, if no `--engine-flags` are given, then every engine is run
+    ///   without any flags.
+    ///
+    /// - Otherwise, if exactly one `--engine-flags` is given, then it is applied
+    ///   to every engine.
+    ///
+    /// - Otherwise, it is an error.
+    ///
+    /// For example, using the same engine to compare Wasmtime's two garbage
+    /// collectors:
+    ///
+    /// ```text
+    /// sightglass-cli benchmark \
+    ///     -e engines/wasmtime/libengine.dylib \
+    ///     --engine-flags "-Ccollector=copying" \
+    ///     --engine-flags "-Ccollector=drc" \
+    ///     -- benchmarks/splay/splay.wasm
+    /// ```
+    ///
+    /// For example, comparing two different engines with the same non-default flags:
+    ///
+    /// ```text
+    /// sightglass-cli benchmark \
+    ///     -e path/to/main.dylib \
+    ///     -e path/to/feature.dylib \
+    ///     --engine-flags "-Ccollector=drc" \
+    ///     -- benchmarks/splay/splay.wasm
+    /// ```
     #[arg(
         long = "engine-flags",
         value_name = "ENGINE_FLAGS",
         allow_hyphen_values = true
     )]
-    engine_flags: Option<String>,
+    engine_flags: Vec<String>,
 
     /// How many processes should we use for each Wasm benchmark?
     ///
@@ -387,8 +431,8 @@ impl BenchmarkCommand {
         if self.should_wrap_subprocesses() {
             let this_exe =
                 std::env::current_exe().context("failed to get the current executable's path")?;
-            return self.execute_in_subprocesses("callgrind iterations", |engine, wasm| {
-                self.prepare_command(&this_exe, engine, wasm)
+            return self.execute_in_subprocesses("callgrind iterations", |engine, flags, wasm| {
+                self.prepare_command(&this_exe, engine, flags, wasm)
             });
         }
 
@@ -399,6 +443,14 @@ impl BenchmarkCommand {
         }
     }
 
+    fn validate(&self) -> Result<()> {
+        self.validate_callgrind()?;
+        // Validate the engines/engine-flags pairing up front so that we fail
+        // fast before spawning any benchmark processes.
+        self.engine_flag_pairs()?;
+        Ok(())
+    }
+
     fn processes(&self) -> usize {
         self.processes.unwrap_or_else(|| self.default_processes())
     }
@@ -406,6 +458,43 @@ impl BenchmarkCommand {
     fn iterations_per_process(&self) -> usize {
         self.iterations_per_process
             .unwrap_or_else(|| self.default_iterations_per_process())
+    }
+
+    /// Pair each engine with the flags it should be configured with.
+    fn engine_flag_pairs(&self) -> Result<Vec<(&str, Option<&str>)>> {
+        let engines = &self.engines;
+        let flags = &self.engine_flags;
+        if engines.len() == 1 && flags.len() > 1 {
+            // Pair the single engine with each set of flags.
+            Ok(flags
+                .iter()
+                .map(|f| (engines[0].as_str(), Some(f.as_str())))
+                .collect())
+        } else if flags.len() == engines.len() {
+            // Pair each engine with the flags in the same position.
+            Ok(engines
+                .iter()
+                .zip(flags)
+                .map(|(e, f)| (e.as_str(), Some(f.as_str())))
+                .collect())
+        } else if flags.is_empty() {
+            // Pair each engine with empty (no) flags.
+            Ok(engines.iter().map(|e| (e.as_str(), None)).collect())
+        } else if flags.len() == 1 {
+            // Pair each engine with the single set of flags.
+            Ok(engines
+                .iter()
+                .map(|e| (e.as_str(), Some(flags[0].as_str())))
+                .collect())
+        } else {
+            anyhow::bail!(
+                "mismatched numbers of engines ({}) and engine flags ({}): pass either no \
+                 `--engine-flags`, exactly one (which is applied to every engine), one per \
+                 engine, or one engine with multiple flags",
+                engines.len(),
+                flags.len(),
+            );
+        }
     }
 
     /// Execute benchmark(s) in the provided engine(s) using the current process.
@@ -424,7 +513,7 @@ impl BenchmarkCommand {
             .collect();
         let mut all_measurements = vec![];
 
-        for (i, engine_name) in self.engines.iter().enumerate() {
+        for (i, (engine_name, engine_flags)) in self.engine_flag_pairs()?.into_iter().enumerate() {
             let engine_path = check_engine_path(engine_name)?;
             let engine_name = self
                 .names
@@ -466,7 +555,7 @@ impl BenchmarkCommand {
 
                 let engine = sightglass_data::Engine {
                     name: engine_name.into(),
-                    flags: self.engine_flags.as_ref().map(|ef| ef.into()),
+                    flags: engine_flags.map(|ef| ef.into()),
                 };
                 let mut measurements = Measurements::new(this_arch(), engine, wasm_file);
                 let mut measure = if self.measures.len() <= 1 {
@@ -486,7 +575,7 @@ impl BenchmarkCommand {
                     stdin,
                     &mut measurements,
                     &mut measure,
-                    self.engine_flags.as_deref(),
+                    engine_flags,
                 );
                 let mut engine = Some(engine);
 
@@ -617,7 +706,7 @@ impl BenchmarkCommand {
     fn execute_in_multiple_processes(&self) -> Result<()> {
         let this_exe =
             std::env::current_exe().context("failed to get the current executable's path")?;
-        self.execute_in_subprocesses("iterations", |engine, wasm| {
+        self.execute_in_subprocesses("iterations", |engine, flags, wasm| {
             let mut prepared = PreparedCommand::new(
                 Command::new(&this_exe),
                 "benchmark subprocess",
@@ -632,6 +721,7 @@ impl BenchmarkCommand {
             self.add_benchmark_child_args(
                 &mut prepared.command,
                 engine,
+                flags,
                 wasm,
                 1,
                 self.iterations_per_process(),
@@ -647,7 +737,7 @@ impl BenchmarkCommand {
         mut prepare_command: F,
     ) -> Result<()>
     where
-        F: FnMut(&Path, &Path) -> Result<PreparedCommand>,
+        F: FnMut(&Path, Option<&str>, &Path) -> Result<PreparedCommand>,
     {
         let mut output_file = self.make_output_writer()?;
 
@@ -675,14 +765,15 @@ impl BenchmarkCommand {
         // Worklist that we randomly sample from.
         let mut choices = vec![];
 
-        for engine in &self.engines {
+        for (engine, flags) in self.engine_flag_pairs()? {
             // Ensure that each of our engines is built before we spawn any
             // child processes (potentially in a different working directory,
             // and therefore potentially invalidating relative paths used here).
             let engine = check_engine_path(engine)?;
+            let flags = flags.map(|f| f.to_string());
 
             for wasm in wasm_files.iter().cloned() {
-                choices.push((engine.clone(), wasm, self.processes()));
+                choices.push((engine.clone(), flags.clone(), wasm, self.processes()));
             }
         }
 
@@ -695,8 +786,8 @@ impl BenchmarkCommand {
 
         while !choices.is_empty() {
             let index = rng.gen_range(0, choices.len());
-            let (engine, wasm, procs_left) = &mut choices[index];
-            let mut prepared = prepare_command(engine, wasm)?;
+            let (engine, flags, wasm, procs_left) = &mut choices[index];
+            let mut prepared = prepare_command(engine, flags.as_deref(), wasm)?;
             let output = prepared
                 .command
                 .output()
@@ -797,7 +888,10 @@ impl BenchmarkCommand {
             let mut measurements = measurements.to_vec();
             measurements.extend(sum_totals(&measurements));
 
-            if self.summary || self.engines.len() == 1 {
+            // Compare engine configurations against each other, unless there is
+            // only one of them (a single engine with a single set of flags) or
+            // the user explicitly asked for summaries.
+            if self.summary || self.engine_flag_pairs()?.len() == 1 {
                 display_summaries(&measurements, output_file)?;
             } else {
                 self.display_effect_sizes(&measurements, output_file)?;
@@ -876,6 +970,7 @@ impl BenchmarkCommand {
         &self,
         command: &mut Command,
         engine: &Path,
+        engine_flags: Option<&str>,
         wasm: &Path,
         processes: usize,
         iterations_per_process: usize,
@@ -914,7 +1009,7 @@ impl BenchmarkCommand {
             command.arg("--benchmark-phase").arg(phase.to_string());
         }
 
-        if let Some(flags) = self.engine_flags.as_deref() {
+        if let Some(flags) = engine_flags {
             command.arg(format!("--engine-flags={flags}"));
         }
 
@@ -1312,6 +1407,95 @@ execution
     }
 
     #[test]
+    fn engine_flag_pairing() -> Result<()> {
+        // Parse a benchmark command with the given engine/flag arguments. The
+        // trailing `dummy.wasm` avoids touching the default suite file.
+        let command = |args: &[&str]| -> Result<BenchmarkCommand> {
+            let mut full = vec!["benchmark"];
+            full.extend_from_slice(args);
+            full.push("dummy.wasm");
+            Ok(BenchmarkCommand::try_parse_from(full)?)
+        };
+
+        // Equal counts: paired by position.
+        let c = command(&[
+            "-e",
+            "a",
+            "-e",
+            "b",
+            "--engine-flags",
+            "x",
+            "--engine-flags",
+            "y",
+        ])?;
+        assert_eq!(
+            c.engine_flag_pairs()?,
+            vec![("a", Some("x")), ("b", Some("y"))]
+        );
+
+        // No flags: every engine runs without any flags.
+        let c = command(&["-e", "a", "-e", "b"])?;
+        assert_eq!(c.engine_flag_pairs()?, vec![("a", None), ("b", None)]);
+
+        // A single set of flags: applied to every engine.
+        let c = command(&["-e", "a", "-e", "b", "--engine-flags", "x"])?;
+        assert_eq!(
+            c.engine_flag_pairs()?,
+            vec![("a", Some("x")), ("b", Some("x"))]
+        );
+
+        // A single engine with multiple sets of flags: paired with each.
+        let c = command(&[
+            "-e",
+            "a",
+            "--engine-flags",
+            "x",
+            "--engine-flags",
+            "y",
+            "--engine-flags",
+            "z",
+        ])?;
+        assert_eq!(
+            c.engine_flag_pairs()?,
+            vec![("a", Some("x")), ("a", Some("y")), ("a", Some("z"))]
+        );
+
+        // The same engine can be repeated, and an empty flags value is a
+        // distinct, valid configuration.
+        let c = command(&[
+            "-e",
+            "wasmtime",
+            "-e",
+            "wasmtime",
+            "--engine-flags",
+            "",
+            "--engine-flags",
+            "-W fuel=1",
+        ])?;
+        assert_eq!(
+            c.engine_flag_pairs()?,
+            vec![("wasmtime", Some("")), ("wasmtime", Some("-W fuel=1"))]
+        );
+
+        // Mismatched counts (neither equal, nor one, nor zero) is an error.
+        let c = command(&[
+            "-e",
+            "a",
+            "-e",
+            "b",
+            "-e",
+            "c",
+            "--engine-flags",
+            "x",
+            "--engine-flags",
+            "y",
+        ])?;
+        assert!(c.engine_flag_pairs().is_err());
+
+        Ok(())
+    }
+
+    #[test]
     fn summary_flag_forces_summaries() -> Result<()> {
         let fixture = std::fs::read("../../test/fixtures/old-vs-new-backend.json")
             .context("failed to read fixture file")?;
@@ -1475,7 +1659,7 @@ instantiation :: nanoseconds :: pulldown-cmark
         let command = BenchmarkCommand {
             benchmarks: vec![],
             engines: vec!["/tmp/engine.so".into()],
-            engine_flags: None,
+            engine_flags: vec![],
             processes: None,
             names: None,
             iterations_per_process: None,

--- a/crates/cli/src/benchmark.rs
+++ b/crates/cli/src/benchmark.rs
@@ -232,47 +232,38 @@ pub struct BenchmarkCommand {
     #[arg(long = "engine", short = 'e', value_name = "PATH")]
     engines: Vec<String>,
 
-    /// Configure the engine(s) using engine-specific flags.
+    /// Configure an individual engine using engine-specific flags.
     ///
     /// For a Wasmtime-based engine, for example, these can be a subset of flags
     /// from `wasmtime run --help`.
     ///
-    /// This may be passed multiple times and is paired with the engines
-    /// (`-e`/`--engine`) as follows:
+    /// You must either pass no `--engine-flags` at all, or exactly one per
+    /// engine. When given, each set of flags is paired with the engine
+    /// (`-e`/`--engine`) at the same position: the Nth `--engine-flags` applies
+    /// to the Nth engine.
     ///
-    /// - If there is a single engine and more than one set of `--engine-flags`,
-    ///   then that engine is paired with each set of flags.
+    /// To instead apply the same flags to *every* engine, use
+    /// `--engine-flags-common`. The two may also be combined, in which case the
+    /// common flags are applied to each engine before its own flags.
     ///
-    /// - Otherwise, if the number of `--engine-flags` equals the number of
-    ///   engines, then each engine is paired with the flags in the same
-    ///   position.
-    ///
-    /// - Otherwise, if no `--engine-flags` are given, then every engine is run
-    ///   without any flags.
-    ///
-    /// - Otherwise, if exactly one `--engine-flags` is given, then it is applied
-    ///   to every engine.
-    ///
-    /// - Otherwise, it is an error.
-    ///
-    /// For example, using the same engine to compare Wasmtime's two garbage
-    /// collectors:
+    /// For example, comparing two different engines, each configured with its
+    /// own flags:
     ///
     /// ```text
     /// sightglass-cli benchmark \
-    ///     -e engines/wasmtime/libengine.dylib \
-    ///     --engine-flags "-Ccollector=copying" \
-    ///     --engine-flags "-Ccollector=drc" \
-    ///     -- benchmarks/splay/splay.wasm
+    ///     -e path/to/main.dylib --engine-flags "-Ccompiler=winch" \
+    ///     -e path/to/feature.dylib --engine-flags "-Ccompiler=cranelift" \
+    ///     -- benchmarks/pulldown-cmark/benchmark.wasm
     /// ```
     ///
-    /// For example, comparing two different engines with the same non-default flags:
+    /// Alternatively, the same engine may be repeated to compare it against
+    /// itself under different flags, for example comparing Wasmtime's DRC and
+    /// copying garbage collectors:
     ///
     /// ```text
     /// sightglass-cli benchmark \
-    ///     -e path/to/main.dylib \
-    ///     -e path/to/feature.dylib \
-    ///     --engine-flags "-Ccollector=drc" \
+    ///     -e engines/wasmtime/libengine.dylib --engine-flags "-Ccollector=copying" \
+    ///     -e engines/wasmtime/libengine.dylib --engine-flags "-Ccollector=drc" \
     ///     -- benchmarks/splay/splay.wasm
     /// ```
     #[arg(
@@ -281,6 +272,31 @@ pub struct BenchmarkCommand {
         allow_hyphen_values = true
     )]
     engine_flags: Vec<String>,
+
+    /// Configure every engine using these common engine flags.
+    ///
+    /// Unlike `--engine-flags`, which is paired with an individual engine,
+    /// these flags are applied to all of the engines (`-e`/`--engine`), which
+    /// is a convenient way to configure several engines identically.
+    ///
+    /// For example, to enable Wasmtime's DRC collector for all engines:
+    ///
+    /// ```text
+    /// sightglass-cli benchmark \
+    ///     -e path/to/main.dylib \
+    ///     -e path/to/feature.dylib \
+    ///     --engine-flags-common "-Ccollector=drc" \
+    ///     -- benchmarks/splay/splay.wasm
+    /// ```
+    ///
+    /// These may also be combined with per-engine `--engine-flags`, in which
+    /// case the common flags are applied to each engine before its own flags.
+    #[arg(
+        long = "engine-flags-common",
+        value_name = "ENGINE_FLAGS",
+        allow_hyphen_values = true
+    )]
+    engine_flags_common: Option<String>,
 
     /// How many processes should we use for each Wasm benchmark?
     ///
@@ -461,39 +477,50 @@ impl BenchmarkCommand {
     }
 
     /// Pair each engine with the flags it should be configured with.
-    fn engine_flag_pairs(&self) -> Result<Vec<(&str, Option<&str>)>> {
+    ///
+    /// Each engine is configured with the common `--engine-flags-common` flags
+    /// (if any) followed by its own positional `--engine-flags` (if any). The
+    /// per-engine `--engine-flags` must either be omitted entirely or given
+    /// exactly once per engine.
+    fn engine_flag_pairs(&self) -> Result<Vec<(&str, Option<String>)>> {
         let engines = &self.engines;
-        let flags = &self.engine_flags;
-        if engines.len() == 1 && flags.len() > 1 {
-            // Pair the single engine with each set of flags.
-            Ok(flags
-                .iter()
-                .map(|f| (engines[0].as_str(), Some(f.as_str())))
-                .collect())
-        } else if flags.len() == engines.len() {
-            // Pair each engine with the flags in the same position.
-            Ok(engines
-                .iter()
-                .zip(flags)
-                .map(|(e, f)| (e.as_str(), Some(f.as_str())))
-                .collect())
-        } else if flags.is_empty() {
-            // Pair each engine with empty (no) flags.
-            Ok(engines.iter().map(|e| (e.as_str(), None)).collect())
-        } else if flags.len() == 1 {
-            // Pair each engine with the single set of flags.
-            Ok(engines
-                .iter()
-                .map(|e| (e.as_str(), Some(flags[0].as_str())))
-                .collect())
-        } else {
-            anyhow::bail!(
-                "mismatched numbers of engines ({}) and engine flags ({}): pass either no \
-                 `--engine-flags`, exactly one (which is applied to every engine), one per \
-                 engine, or one engine with multiple flags",
-                engines.len(),
-                flags.len(),
-            );
+        let common = self.engine_flags_common.as_deref();
+        let per_engine = &self.engine_flags;
+
+        anyhow::ensure!(
+            per_engine.is_empty() || per_engine.len() == engines.len(),
+            "mismatched numbers of engines ({}) and `--engine-flags` ({}): pass either no \
+             `--engine-flags` or exactly one per engine (use `--engine-flags-common` to apply \
+             the same flags to every engine)",
+            engines.len(),
+            per_engine.len(),
+        );
+
+        Ok(engines
+            .iter()
+            .enumerate()
+            .map(|(i, engine)| {
+                let per_engine = per_engine.get(i).map(String::as_str);
+                (
+                    engine.as_str(),
+                    Self::combine_engine_flags(common, per_engine),
+                )
+            })
+            .collect())
+    }
+
+    /// Combine the common engine flags with a single engine's own flags.
+    ///
+    /// A present-but-empty per-engine flag string is preserved as a distinct
+    /// (empty) configuration, so that the same engine can be compared against
+    /// itself with and without flags.
+    fn combine_engine_flags(common: Option<&str>, per_engine: Option<&str>) -> Option<String> {
+        match (common, per_engine) {
+            (None, None) => None,
+            (Some(flags), None) | (None, Some(flags)) => Some(flags.to_string()),
+            (Some(common), Some(per_engine)) => {
+                Some(format!("{common} {per_engine}").trim().to_string())
+            }
         }
     }
 
@@ -511,10 +538,13 @@ impl BenchmarkCommand {
             .flat_map(|f| f.paths())
             .map(|p| p.display().to_string())
             .collect();
+
+        let engine_flag_pairs = self.engine_flag_pairs()?;
         let mut all_measurements = vec![];
 
-        for (i, (engine_name, engine_flags)) in self.engine_flag_pairs()?.into_iter().enumerate() {
-            let engine_path = check_engine_path(engine_name)?;
+        for (i, (engine_name, engine_flags)) in engine_flag_pairs.iter().enumerate() {
+            let engine_flags = engine_flags.as_deref();
+            let engine_path = check_engine_path(*engine_name)?;
             let engine_name = self
                 .names
                 .as_ref()
@@ -770,7 +800,6 @@ impl BenchmarkCommand {
             // child processes (potentially in a different working directory,
             // and therefore potentially invalidating relative paths used here).
             let engine = check_engine_path(engine)?;
-            let flags = flags.map(|f| f.to_string());
 
             for wasm in wasm_files.iter().cloned() {
                 choices.push((engine.clone(), flags.clone(), wasm, self.processes()));
@@ -1408,89 +1437,135 @@ execution
 
     #[test]
     fn engine_flag_pairing() -> Result<()> {
-        // Parse a benchmark command with the given engine/flag arguments. The
-        // trailing `dummy.wasm` avoids touching the default suite file.
-        let command = |args: &[&str]| -> Result<BenchmarkCommand> {
+        // Parse a benchmark command with the given engine/flag arguments and
+        // return its (engine, flags) pairs as owned values. The trailing
+        // `dummy.wasm` avoids touching the default suite file.
+        let pairs = |args: &[&str]| -> Result<Vec<(String, Option<String>)>> {
             let mut full = vec!["benchmark"];
             full.extend_from_slice(args);
             full.push("dummy.wasm");
-            Ok(BenchmarkCommand::try_parse_from(full)?)
+            let command = BenchmarkCommand::try_parse_from(full)?;
+            Ok(command
+                .engine_flag_pairs()?
+                .into_iter()
+                .map(|(e, f)| (e.to_string(), f))
+                .collect())
         };
 
-        // Equal counts: paired by position.
-        let c = command(&[
-            "-e",
-            "a",
-            "-e",
-            "b",
-            "--engine-flags",
-            "x",
-            "--engine-flags",
-            "y",
-        ])?;
+        // Build the expected owned pairs from string literals.
+        let expect = |pairs: &[(&str, Option<&str>)]| -> Vec<(String, Option<String>)> {
+            pairs
+                .iter()
+                .map(|(e, f)| (e.to_string(), f.map(String::from)))
+                .collect()
+        };
+
+        // Equal counts: `--engine-flags` is paired with each engine by position.
         assert_eq!(
-            c.engine_flag_pairs()?,
-            vec![("a", Some("x")), ("b", Some("y"))]
+            pairs(&[
+                "-e",
+                "a",
+                "-e",
+                "b",
+                "--engine-flags",
+                "x",
+                "--engine-flags",
+                "y"
+            ])?,
+            expect(&[("a", Some("x")), ("b", Some("y"))]),
         );
 
-        // No flags: every engine runs without any flags.
-        let c = command(&["-e", "a", "-e", "b"])?;
-        assert_eq!(c.engine_flag_pairs()?, vec![("a", None), ("b", None)]);
-
-        // A single set of flags: applied to every engine.
-        let c = command(&["-e", "a", "-e", "b", "--engine-flags", "x"])?;
+        // No flags at all: every engine runs without any flags.
         assert_eq!(
-            c.engine_flag_pairs()?,
-            vec![("a", Some("x")), ("b", Some("x"))]
+            pairs(&["-e", "a", "-e", "b"])?,
+            expect(&[("a", None), ("b", None)]),
         );
 
-        // A single engine with multiple sets of flags: paired with each.
-        let c = command(&[
-            "-e",
-            "a",
-            "--engine-flags",
-            "x",
-            "--engine-flags",
-            "y",
-            "--engine-flags",
-            "z",
-        ])?;
+        // A single engine with a single set of flags.
         assert_eq!(
-            c.engine_flag_pairs()?,
-            vec![("a", Some("x")), ("a", Some("y")), ("a", Some("z"))]
+            pairs(&["-e", "a", "--engine-flags", "x"])?,
+            expect(&[("a", Some("x"))]),
         );
 
-        // The same engine can be repeated, and an empty flags value is a
-        // distinct, valid configuration.
-        let c = command(&[
-            "-e",
-            "wasmtime",
-            "-e",
-            "wasmtime",
-            "--engine-flags",
-            "",
-            "--engine-flags",
-            "-W fuel=1",
-        ])?;
+        // `--engine-flags-common` is applied to every engine.
         assert_eq!(
-            c.engine_flag_pairs()?,
-            vec![("wasmtime", Some("")), ("wasmtime", Some("-W fuel=1"))]
+            pairs(&["-e", "a", "-e", "b", "--engine-flags-common", "c"])?,
+            expect(&[("a", Some("c")), ("b", Some("c"))]),
         );
 
-        // Mismatched counts (neither equal, nor one, nor zero) is an error.
-        let c = command(&[
-            "-e",
-            "a",
-            "-e",
-            "b",
-            "-e",
-            "c",
-            "--engine-flags",
-            "x",
-            "--engine-flags",
-            "y",
-        ])?;
-        assert!(c.engine_flag_pairs().is_err());
+        // Common and per-engine flags compose: the common flags come first,
+        // followed by each engine's own flags.
+        assert_eq!(
+            pairs(&[
+                "-e",
+                "a",
+                "-e",
+                "b",
+                "--engine-flags-common",
+                "c",
+                "--engine-flags",
+                "x",
+                "--engine-flags",
+                "y",
+            ])?,
+            expect(&[("a", Some("c x")), ("b", Some("c y"))]),
+        );
+
+        // When an engine's own flags are empty, only the common flags remain
+        // (with no stray trailing whitespace).
+        assert_eq!(
+            pairs(&[
+                "-e",
+                "a",
+                "-e",
+                "b",
+                "--engine-flags-common",
+                "c",
+                "--engine-flags",
+                "x",
+                "--engine-flags",
+                "",
+            ])?,
+            expect(&[("a", Some("c x")), ("b", Some("c"))]),
+        );
+
+        // The same engine can be repeated to compare it against itself under
+        // different flags; an empty flags value is a distinct configuration.
+        assert_eq!(
+            pairs(&[
+                "-e",
+                "wasmtime",
+                "-e",
+                "wasmtime",
+                "--engine-flags",
+                "",
+                "--engine-flags",
+                "-W fuel=1",
+            ])?,
+            expect(&[("wasmtime", Some("")), ("wasmtime", Some("-W fuel=1"))]),
+        );
+
+        // A single set of per-engine flags is *not* silently applied to all
+        // engines; `--engine-flags-common` must be used for that instead.
+        assert!(pairs(&["-e", "a", "-e", "b", "--engine-flags", "x"]).is_err());
+
+        // Any other mismatch between the engine and per-engine flag counts is
+        // an error.
+        assert!(
+            pairs(&[
+                "-e",
+                "a",
+                "-e",
+                "b",
+                "-e",
+                "c",
+                "--engine-flags",
+                "x",
+                "--engine-flags",
+                "y",
+            ])
+            .is_err()
+        );
 
         Ok(())
     }
@@ -1660,6 +1735,7 @@ instantiation :: nanoseconds :: pulldown-cmark
             benchmarks: vec![],
             engines: vec!["/tmp/engine.so".into()],
             engine_flags: vec![],
+            engine_flags_common: None,
             processes: None,
             names: None,
             iterations_per_process: None,

--- a/crates/cli/src/pca_metrics/dynamic_metrics.rs
+++ b/crates/cli/src/pca_metrics/dynamic_metrics.rs
@@ -7,6 +7,7 @@ mod component;
 use super::Counts;
 use super::category::{Category, NUM_CATEGORIES};
 use anyhow::{Context, Result, bail};
+#[cfg(any(test, all(target_os = "linux", feature = "callgrind")))]
 use sightglass_data::{Measurement, Phase};
 use std::path::Path;
 #[cfg(all(target_os = "linux", feature = "callgrind"))]
@@ -139,6 +140,7 @@ fn callgrind_metrics(
     Ok(())
 }
 
+#[cfg(any(test, all(target_os = "linux", feature = "callgrind")))]
 fn accumulate_callgrind_counts(measurements: &[Measurement<'_>], counts: &mut Counts) {
     for measurement in measurements {
         if measurement.phase != Phase::Execution {

--- a/crates/cli/tests/all/benchmark.rs
+++ b/crates/cli/tests/all/benchmark.rs
@@ -221,7 +221,7 @@ fn alt_test_engine() -> PathBuf {
     alt_path
 }
 
-/// A single engine (passed once) can be compared against itself with different
+/// The same engine can be repeated to compare it against itself with different
 /// flags: no flags vs. fuel vs. epoch interruption.
 #[test]
 #[cfg_attr(target_os = "windows", ignore)] // TODO: https://github.com/bytecodealliance/sightglass/issues/178
@@ -229,6 +229,10 @@ fn benchmark_single_engine_multiple_flags() {
     let engine = test_engine();
     sightglass_cli()
         .arg("benchmark")
+        .arg("-e")
+        .arg(&engine)
+        .arg("-e")
+        .arg(&engine)
         .arg("-e")
         .arg(&engine)
         .arg("--engine-flags")
@@ -254,10 +258,10 @@ fn benchmark_single_engine_multiple_flags() {
         );
 }
 
-/// A single set of engine flags applies to every engine.
+/// A single set of `--engine-flags-common` applies to every engine.
 #[test]
 #[cfg_attr(target_os = "windows", ignore)] // TODO: https://github.com/bytecodealliance/sightglass/issues/178
-fn benchmark_multiple_engines_single_flags() {
+fn benchmark_multiple_engines_common_flags() {
     let engine = test_engine();
     let alt = alt_test_engine();
     sightglass_cli()
@@ -266,7 +270,7 @@ fn benchmark_multiple_engines_single_flags() {
         .arg(&engine)
         .arg("-e")
         .arg(&alt)
-        .arg("--engine-flags")
+        .arg("--engine-flags-common")
         .arg("-W fuel=99999999")
         .arg("--processes")
         .arg("1")
@@ -304,6 +308,43 @@ fn benchmark_multiple_engines_multiple_flags() {
         .assert()
         .success()
         .stdout(predicate::str::contains("compilation :: cycles :: noop"));
+}
+
+/// `--engine-flags-common` composes with per-engine `--engine-flags`: the common
+/// flags are applied to every engine, followed by that engine's own flags. Here
+/// the same engine is repeated so the configurations are labeled by their
+/// (composed) flags.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // TODO: https://github.com/bytecodealliance/sightglass/issues/178
+fn benchmark_common_and_per_engine_flags() {
+    let engine = test_engine();
+    sightglass_cli()
+        .arg("benchmark")
+        .arg("-e")
+        .arg(&engine)
+        .arg("-e")
+        .arg(&engine)
+        .arg("--engine-flags-common")
+        .arg("-W fuel=99999999")
+        .arg("--engine-flags")
+        .arg("")
+        .arg("--engine-flags")
+        .arg("-W epoch-interruption=y")
+        .arg("--processes")
+        .arg("1")
+        .arg("--iterations-per-process")
+        .arg("5")
+        .arg("--show-insignificant")
+        .arg(benchmark("noop"))
+        .assert()
+        .success()
+        .stdout(
+            // Both configurations get the common `fuel` flag; only the second
+            // additionally gets `epoch-interruption`.
+            predicate::str::contains("compilation :: cycles :: noop")
+                .and(predicate::str::contains("fuel=99999999"))
+                .and(predicate::str::contains("epoch-interruption=y")),
+        );
 }
 
 /// With multiple benchmarks and non-raw (summary) output, a "Sum Total" row is

--- a/crates/cli/tests/all/benchmark.rs
+++ b/crates/cli/tests/all/benchmark.rs
@@ -209,6 +209,103 @@ fn benchmark_effect_size() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Make a second, distinct on-disk copy of the test engine so we can benchmark
+/// multiple engines.
+fn alt_test_engine() -> PathBuf {
+    let engine = test_engine();
+    let alt = tempfile::NamedTempFile::new().unwrap();
+    let alt_path: PathBuf = alt.path().into();
+    alt.close().unwrap();
+    std::fs::copy(&engine, &alt_path).unwrap();
+    assert!(alt_path.exists());
+    alt_path
+}
+
+/// A single engine (passed once) can be compared against itself with different
+/// flags: no flags vs. fuel vs. epoch interruption.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // TODO: https://github.com/bytecodealliance/sightglass/issues/178
+fn benchmark_single_engine_multiple_flags() {
+    let engine = test_engine();
+    sightglass_cli()
+        .arg("benchmark")
+        .arg("-e")
+        .arg(&engine)
+        .arg("--engine-flags")
+        .arg("")
+        .arg("--engine-flags")
+        .arg("-W fuel=99999999")
+        .arg("--engine-flags")
+        .arg("-W epoch-interruption=y")
+        .arg("--processes")
+        .arg("1")
+        .arg("--iterations-per-process")
+        .arg("5")
+        .arg("--show-insignificant")
+        .arg(benchmark("noop"))
+        .assert()
+        .success()
+        .stdout(
+            // The engine is compared against itself, so the configurations are
+            // labeled by their flags.
+            predicate::str::contains("compilation :: cycles :: noop")
+                .and(predicate::str::contains("fuel=99999999"))
+                .and(predicate::str::contains("epoch-interruption=y")),
+        );
+}
+
+/// A single set of engine flags applies to every engine.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // TODO: https://github.com/bytecodealliance/sightglass/issues/178
+fn benchmark_multiple_engines_single_flags() {
+    let engine = test_engine();
+    let alt = alt_test_engine();
+    sightglass_cli()
+        .arg("benchmark")
+        .arg("-e")
+        .arg(&engine)
+        .arg("-e")
+        .arg(&alt)
+        .arg("--engine-flags")
+        .arg("-W fuel=99999999")
+        .arg("--processes")
+        .arg("1")
+        .arg("--iterations-per-process")
+        .arg("5")
+        .arg("--show-insignificant")
+        .arg(benchmark("noop"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("compilation :: cycles :: noop"));
+}
+
+/// Multiple engines can each be paired with their own flags.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // TODO: https://github.com/bytecodealliance/sightglass/issues/178
+fn benchmark_multiple_engines_multiple_flags() {
+    let engine = test_engine();
+    let alt = alt_test_engine();
+    sightglass_cli()
+        .arg("benchmark")
+        .arg("-e")
+        .arg(&engine)
+        .arg("-e")
+        .arg(&alt)
+        .arg("--engine-flags")
+        .arg("-W fuel=99999999")
+        .arg("--engine-flags")
+        .arg("-W epoch-interruption=y")
+        .arg("--processes")
+        .arg("1")
+        .arg("--iterations-per-process")
+        .arg("5")
+        .arg("--show-insignificant")
+        .arg(benchmark("noop"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("compilation :: cycles :: noop"));
+}
+
 /// With multiple benchmarks and non-raw (summary) output, a "Sum Total" row is
 /// added that sums each sample's counts across the benchmarks. Using a single
 /// process makes the per-sample sums span both benchmarks.


### PR DESCRIPTION
Change `--engine-flags` to accept multiple values and pair them with the engines as follows:

- A single engine with multiple flag sets is paired with each set

- Multiple engines with zero or one flag set pairs each engine with the flag set (if any)

- N engines and N flag sets are paired together by position: `engines[i]` with `flags[i]`

- All other combinations are errors.

This allows, for example, comparing the performance effects of different flags for the same engine, e.g. the DRC vs copying collector:

```
sightglass-cli benchmark \
    -e engines/wasmtime/libengine.dylib \
    --engine-flags "-Ccollector=copying" \
    --engine-flags "-Ccollector=drc" \
    -- benchmarks/splay/splay.wasm
```